### PR TITLE
Version should increase, not reset to 1.0.0

### DIFF
--- a/algolia.php
+++ b/algolia.php
@@ -5,7 +5,7 @@
  * Plugin Name:       WP Search with Algolia
  * Plugin URI:        https://github.com/WebDevStudios/wp-search-with-algolia
  * Description:       Integrate the powerful Algolia search service with WordPress
- * Version:           1.0.0
+ * Version:           2.11.3
  * Author:            WebDevStudios
  * Author URI:        https://webdevstudios.com
  * License:           GNU General Public License v2.0 / MIT License
@@ -36,7 +36,7 @@ if ( version_compare( $wp_version, '4.4', '<' ) ) {
 }
 
 // The Algolia Search plugin version.
-define( 'ALGOLIA_VERSION', '1.0.0' );
+define( 'ALGOLIA_VERSION', '2.11.3' );
 define( 'ALGOLIA_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
 if ( ! defined( 'ALGOLIA_PATH' ) ) {


### PR DESCRIPTION
A version check is performed by related plugins (WooCommerce https://github.com/algolia/algoliasearch-woocommerce) that rely on this plugin. The Algolia Search plugin for WooCommerce was also discontinued by Algolia at the same time as this plugin now supported by WebDevStudio.
When this project was forked by WebDevStudio, the version was reset from 2.11.3 to 1.0.0 .
Any reason? Please just set it to 2.11.3 or above! Easy fix and removes the incompatibility warnings.

The change in plugin folder name from `algoliasearch-wordpress` to `wp-search-with-algolia` was also problematic. I've also reverted that change in my site. Maybe we should just fork Algolia for Woocommerce as well. What are the plans for moving forward with this plugin? Any desire to maintain the fork of Algolia for Woocommerce?