### PR TITLE
The text domain should match the containing folder name

### DIFF
--- a/algolia.php
+++ b/algolia.php
@@ -9,7 +9,7 @@
  * Author:            WebDevStudios
  * Author URI:        https://webdevstudios.com
  * License:           GNU General Public License v2.0 / MIT License
- * Text Domain:       algolia
+ * Text Domain:       wp-search-with-algolia
  * Domain Path:       /languages/
  */
 


### PR DESCRIPTION
Reviewing the Wordpress Polyglots Slack Channel, I found that this plugin, even when it was "Search by Algolia - Instant & Relevant results", has always had errors with text domain mismatch. C.f. https://codex.wordpress.org/I18n_for_WordPress_Developers

Meta Language Pack error report
```
WP Search with Algolia has been imported
Type
Code
Version
1.0.0
Status
:umbrella_with_rain_drops: Plugin is not compatible with language packs: Wrong text domain in header. (70.25s)
Plugin
WP Search with Algolia | Log | SVN
May 17th```

Seems to be an easy fix.