### PR TITLE
Fix asset include URLs to not contain ../

### DIFF
--- a/algolia.php
+++ b/algolia.php
@@ -38,6 +38,7 @@ if ( version_compare( $wp_version, '4.4', '<' ) ) {
 // The Algolia Search plugin version.
 define( 'ALGOLIA_VERSION', '1.0.0' );
 define( 'ALGOLIA_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
+define( 'ALGOLIA_PLUGIN_URL', plugin_url( __FILE__ ) );
 
 if ( ! defined( 'ALGOLIA_PATH' ) ) {
 	define( 'ALGOLIA_PATH', plugin_dir_path( __FILE__ ) );

--- a/includes/class-algolia-plugin.php
+++ b/includes/class-algolia-plugin.php
@@ -152,15 +152,15 @@ class Algolia_Plugin {
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
 		// CSS.
-		wp_register_style( 'algolia-autocomplete', plugin_dir_url( __FILE__ ) . '../css/algolia-autocomplete.css', array(), ALGOLIA_VERSION, 'screen' );
-		wp_register_style( 'algolia-instantsearch', plugin_dir_url( __FILE__ ) . '../css/algolia-instantsearch.css', array(), ALGOLIA_VERSION, 'screen' );
+		wp_register_style( 'algolia-autocomplete', ALGOLIA_PLUGIN_URL . 'css/algolia-autocomplete.css', array(), ALGOLIA_VERSION, 'screen' );
+		wp_register_style( 'algolia-instantsearch', ALGOLIA_PLUGIN_URL . 'css/algolia-instantsearch.css', array(), ALGOLIA_VERSION, 'screen' );
 
 		// JS.
-		wp_register_script( 'algolia-search', plugin_dir_url( __FILE__ ) . '../js/algoliasearch/algoliasearch.jquery' . $suffix . '.js', array( 'jquery', 'underscore', 'wp-util' ), ALGOLIA_VERSION );
-		wp_register_script( 'algolia-autocomplete', plugin_dir_url( __FILE__ ) . '../js/autocomplete.js/autocomplete' . $suffix . '.js', array( 'jquery', 'underscore', 'wp-util' ), ALGOLIA_VERSION );
-		wp_register_script( 'algolia-autocomplete-noconflict', plugin_dir_url( __FILE__ ) . '../js/autocomplete-noconflict.js', array( 'algolia-autocomplete' ), ALGOLIA_VERSION );
+		wp_register_script( 'algolia-search', ALGOLIA_PLUGIN_URL . 'js/algoliasearch/algoliasearch.jquery' . $suffix . '.js', array( 'jquery', 'underscore', 'wp-util' ), ALGOLIA_VERSION );
+		wp_register_script( 'algolia-autocomplete', ALGOLIA_PLUGIN_URL . 'js/autocomplete.js/autocomplete' . $suffix . '.js', array( 'jquery', 'underscore', 'wp-util' ), ALGOLIA_VERSION );
+		wp_register_script( 'algolia-autocomplete-noconflict', ALGOLIA_PLUGIN_URL . 'js/autocomplete-noconflict.js', array( 'algolia-autocomplete' ), ALGOLIA_VERSION );
 
-		wp_register_script( 'algolia-instantsearch', plugin_dir_url( __FILE__ ) . '../js/instantsearch.js/instantsearch-preact' . $suffix . '.js', array( 'jquery', 'underscore', 'wp-util' ), ALGOLIA_VERSION );
+		wp_register_script( 'algolia-instantsearch', ALGOLIA_PLUGIN_URL . 'js/instantsearch.js/instantsearch-preact' . $suffix . '.js', array( 'jquery', 'underscore', 'wp-util' ), ALGOLIA_VERSION );
 	}
 
 	/**


### PR DESCRIPTION
It's always slightly annoyed me that the asset include URLs in the Algolia plugin contained `../`, this pull fixes that.