### PR TITLE
Prevent search box from being styled in ways other than what's specified in the CSS

### DIFF
--- a/css/algolia-instantsearch.css
+++ b/css/algolia-instantsearch.css
@@ -38,6 +38,10 @@
 	box-sizing: border-box;
 	outline: none;
 	box-shadow: none;
+	appearance:none;
+	-webkit-appearance:none;
+	-moz-appearance:none;
+	-ms-appearance:none;
 }
 
 #algolia-search-box .search-icon {


### PR DESCRIPTION
Without this, I was getting https://cloudup.com/cLMg6yzoP9I (screenshot) on pretty much all sites that use this plugin in Safari. Telling Safari (and others) to not apply special formatting based on it being a search input resolved this issue (screenshot after this change was implemented: https://cloudup.com/cEwn0DO1USb.)

I'm thinking this is safe to implement in this plugin officially, and I'm sure there's plenty of people out there with Safari users that would be grateful that they don't need to fix this themselves.

Btw, I've also posted about this on the official WP.org support forum at https://wordpress.org/support/topic/proposed-fix-prevent-search-box-from-being-styled-in-undesired-ways-by-default/ for better visibility of others potentially experiencing this.