### PR TITLE
Merge sebastianthulin's PR #40 with some minor fixes to master

### DIFF
--- a/includes/watchers/class-algolia-post-changes-watcher.php
+++ b/includes/watchers/class-algolia-post-changes-watcher.php
@@ -49,7 +49,7 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 			return;
 		}
 
-		if ( in_array( $post_id, $this->posts_deleted ) ) {
+		if ( in_array( $post_id, $this->posts_deleted, true ) ) {
 			return;
 		}
 

--- a/includes/watchers/class-algolia-post-changes-watcher.php
+++ b/includes/watchers/class-algolia-post-changes-watcher.php
@@ -77,7 +77,7 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 
 		try {
 			$this->index->delete_item( $post );
-			$this->postsDeleted[] = $post->ID; 
+			$this->posts_deleted[] = $post->ID;
 		} catch ( AlgoliaException $exception ) {
 			error_log( $exception->getMessage() );
 		}


### PR DESCRIPTION
Minor fixes to @sebastianthulin's PR #40

Discussions took place in the original plugin repo's [Issue 775](https://github.com/algolia/algoliasearch-wordpress/issues/775) and [PR 824](https://github.com/algolia/algoliasearch-wordpress/pull/824).

In short, under some circumstances, when a post with a featured image was deleted, there was the potential for the post to accidentally be re-indexed in the `Algolia_Post_Changes_Watcher::sync_item()` method.