### PR TITLE
Update phpxs.xml to allow `algolia` prefix

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -56,7 +56,7 @@
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<!-- Value: replace the function, class, and variable prefixes used. Separate multiple prefixes with a comma. -->
-			<property name="prefixes" type="array" value="webdevstudios,wds,wpswa"/>
+			<property name="prefixes" type="array" value="webdevstudios,wds,wpswa,algolia"/>
 		</properties>
 	</rule>
 


### PR DESCRIPTION
Forgot to allow for legacy `algolia` prefix used by most of the hooks.