### PR TITLE
67 Relax Algolia_API::is_valid_search_api_key() ACL restrictions in local dev

### DIFF
--- a/includes/class-algolia-api.php
+++ b/includes/class-algolia-api.php
@@ -156,6 +156,11 @@ class Algolia_API {
 				unset( $scopes['listIndexes'] );
 			}
 
+			// Short circuit ACL checks for local development.
+			if ( defined( 'WP_LOCAL_DEV' ) && WP_LOCAL_DEV ) {
+				return true;
+			}
+
 			if ( ! empty( $scopes ) ) {
 				// The API key has more permissions than allowed.
 				return false;


### PR DESCRIPTION
If `WP_LOCAL_DEV` constant is defined as `true` in WP-Config, short circuit the Algolia_API::is_valid_search_api_key() ACL checks.