### PR TITLE
Dashboard Widget

### DIFF
--- a/classmap.php
+++ b/classmap.php
@@ -40,6 +40,7 @@ require_once ALGOLIA_PATH . 'includes/watchers/class-algolia-user-changes-watche
 
 if ( is_admin() ) {
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin.php';
+	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin-dashboard-widget.php';
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin-page-autocomplete.php';
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin-page-native-search.php';
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin-page-settings.php';

--- a/includes/admin/class-algolia-admin-dashboard-widget.php
+++ b/includes/admin/class-algolia-admin-dashboard-widget.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Algolia admin dashboard widget.
+ *
+ * @author WebDevStudios <contact@webdevstudios.com>
+ * @since  1.5.0
+ *
+ * @package WebDevStudios\WPSWA
+ */
+
+
+/**
+ * Algolia admin dashboard widget class.
+ *
+ * @since 1.5.0
+ */
+class Algolia_Admin_Dashboard_Widget {
+
+	/**
+	 * The Algolia_Plugin instance.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.5.0
+	 *
+	 * @var Algolia_Plugin
+	 */
+	private $plugin;
+
+	/**
+	 * Algolia_Admin_Page_Settings constructor.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.5.0
+	 *
+	 * @param Algolia_Plugin $plugin The Algolia_Plugin instance.
+	 */
+	public function __construct( Algolia_Plugin $plugin ) {
+		$this->plugin = $plugin;
+
+		add_action( 'wp_dashboard_setup', [ $this, 'register_widget' ] );
+	}
+
+	/**
+	 * Register dashboard widget.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.5.0
+	 */
+	public function register_widget() {
+		wp_add_dashboard_widget(
+			'wpswa_stats_widget',
+			esc_html__( 'Algolia Stats Widget', 'wp-search-with-algolia' ),
+			[ $this, 'display_stats_widget' ]
+		);
+	}
+
+	/**
+	 * Display stats in the widget.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.5.0
+	 */
+	public function display_stats_widget() {
+		$api          = $this->plugin->get_api();
+		$is_reachable = $api->is_reachable();
+		$indices      = [];
+
+		if ( $is_reachable ) {
+			$indices = $api->get_client()->listIndices();
+		}
+
+		require_once dirname( __FILE__ ) . '/partials/dashboard-stats-widget.php';
+	}
+}

--- a/includes/admin/class-algolia-admin-dashboard-widget.php
+++ b/includes/admin/class-algolia-admin-dashboard-widget.php
@@ -8,7 +8,6 @@
  * @package WebDevStudios\WPSWA
  */
 
-
 /**
  * Algolia admin dashboard widget class.
  *

--- a/includes/admin/class-algolia-admin.php
+++ b/includes/admin/class-algolia-admin.php
@@ -53,6 +53,7 @@ class Algolia_Admin {
 		}
 
 		new Algolia_Admin_Page_Settings( $plugin );
+		new Algolia_Admin_Dashboard_Widget( $plugin );
 
 		add_action( 'admin_notices', array( $this, 'display_unmet_requirements_notices' ) );
 	}

--- a/includes/admin/partials/dashboard-stats-widget.php
+++ b/includes/admin/partials/dashboard-stats-widget.php
@@ -9,17 +9,20 @@
  */
 
 if ( $is_reachable ) {
-	$api_status = esc_html__( 'Reachable', 'wp-search-with-algolia' );
+	$api_status = __( 'Reachable', 'wp-search-with-algolia' ); // @codingStandardsIgnoreLine WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 } else {
-	$api_status = esc_html__( 'Not reachable', 'wp-search-with-algolia' );
+	$api_status = __( 'Not reachable', 'wp-search-with-algolia' ); // @codingStandardsIgnoreLine WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 }
 ?>
 
 <div class="main">
 	<p>
 		<?php
-		/* translators: API status */
-		echo sprintf( esc_html__( 'Algolia API Status: %s', 'wp-search-with-algolia' ), $api_status );
+		echo sprintf(
+			/* translators: API status */
+			esc_html__( 'Algolia API Status: %s', 'wp-search-with-algolia' ),
+			esc_html( $api_status )
+		);
 		?>
 	</p>
 	<?php if ( ! empty( $indices['items'] ) ) : ?>
@@ -32,7 +35,9 @@ if ( $is_reachable ) {
 					<td><?php esc_html_e( 'Last Updated', 'wp-search-with-algolia' ); ?></td>
 				</tr>
 			</thead>
-			<?php foreach ( $indices['items'] as $index ) : ?>
+			<?php
+			foreach ( $indices['items'] as $index ) : // @codingStandardsIgnoreLine WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+				?>
 				<tr>
 					<td><?php echo esc_html( $index['name'] ); ?></td>
 					<td><?php echo esc_html( $index['entries'] ); ?></td>

--- a/includes/admin/partials/dashboard-stats-widget.php
+++ b/includes/admin/partials/dashboard-stats-widget.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Dashboard stats widget partial.
+ *
+ * @author WebDevStudios <contact@webdevstudios.com>
+ * @since  1.5.0
+ *
+ * @package WebDevStudios\WPSWA
+ */
+
+if ( $is_reachable ) {
+	$api_status = esc_html__( 'Reachable', 'wp-search-with-algolia' );
+} else {
+	$api_status = esc_html__( 'Not reachable', 'wp-search-with-algolia' );
+}
+?>
+
+<div class="main">
+	<p>
+		<?php
+		/* translators: API status */
+		echo sprintf( esc_html__( 'Algolia API Status: %s', 'wp-search-with-algolia' ), $api_status );
+		?>
+	</p>
+	<?php if ( ! empty( $indices['items'] ) ) : ?>
+		<table class="fixed striped widefat">
+			<thead>
+				<tr>
+					<td><?php esc_html_e( 'Index', 'wp-search-with-algolia' ); ?></td>
+					<td><?php esc_html_e( 'Entries', 'wp-search-with-algolia' ); ?></td>
+					<td><?php esc_html_e( 'Data Size', 'wp-search-with-algolia' ); ?></td>
+					<td><?php esc_html_e( 'Last Updated', 'wp-search-with-algolia' ); ?></td>
+				</tr>
+			</thead>
+			<?php foreach ( $indices['items'] as $index ) : ?>
+				<tr>
+					<td><?php echo esc_html( $index['name'] ); ?></td>
+					<td><?php echo esc_html( $index['entries'] ); ?></td>
+					<td>
+						<?php
+						echo esc_html(
+							Algolia_Utils::get_display_size(
+								(int) $index['dataSize']
+							)
+						);
+						?>
+					</td>
+					<td>
+						<?php
+						echo esc_html(
+							Algolia_Utils::format_datetime( $index['updatedAt'] )
+						);
+						?>
+					</td>
+				</tr>
+			<?php endforeach; ?>
+		</table>
+	<?php endif; ?>
+</div>

--- a/includes/class-algolia-utils.php
+++ b/includes/class-algolia-utils.php
@@ -243,4 +243,47 @@ class Algolia_Utils {
 
 		return $parts;
 	}
+
+	/**
+	 * Get display size.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.5.0
+	 *
+	 * @param int $size_in_bytes Number of bytes.
+	 * @return string
+	 */
+	public static function get_display_size( $size_in_bytes ) {
+		switch ( $size_in_bytes ) {
+			case $size_in_bytes < 1024:
+				$display_size = "{$size_in_bytes} bytes";
+				break;
+			case $size_in_bytes < 1048576:
+				$size         = round( $size_in_bytes / 1024 );
+				$display_size = "{$size} KB";
+				break;
+			default:
+				$size         = round( $size_in_bytes / 1048576, 1 );
+				$display_size = "{$size} MB";
+				break;
+		}
+
+		return $display_size;
+	}
+
+	/**
+	 * Format datetime string.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.5.0
+	 *
+	 * @param string $datetime Datetime string.
+	 * @return string|false
+	 */
+	public static function format_datetime( $datetime ) {
+		$timestamp   = strtotime( $datetime );
+		$date_format = get_option( 'date_format', 'F j, Y' );
+		$time_format = get_option( 'time_format', 'g:i a' );
+		return date( $date_format . ' ' . $time_format, $timestamp );
+	}
 }


### PR DESCRIPTION
## Description

This PR adds an admin dashboard widget to view general statistics of the indices in Algolia API. These stats can help a user understand the status of their API indexing from the dashboard. The only other way to views these stats right now is by logging in to Algolia's website.

Related issue: #78 

## Screenshot
![Admin Dashboard Widget](https://user-images.githubusercontent.com/8023941/91607202-f3036280-e98c-11ea-8984-56a5a6d29a6c.jpg)
