### PR TITLE
Deletion of posts created before indexing

### DIFF
--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -400,9 +400,13 @@ abstract class Algolia_Index {
 				$this->delete_item( $item );
 				continue;
 			}
+
 			do_action( 'algolia_before_get_records', $item );
-			$records = array_merge( $records, $this->get_records( $item ) );
+			$item_records = $this->get_records( $item );
+			$records = array_merge( $records, $item_records );
 			do_action( 'algolia_after_get_records', $item );
+
+			$this->update_records( $item, $item_records );
 		}
 
 		if ( ! empty( $records ) ) {

--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -403,7 +403,7 @@ abstract class Algolia_Index {
 
 			do_action( 'algolia_before_get_records', $item );
 			$item_records = $this->get_records( $item );
-			$records = array_merge( $records, $item_records );
+			$records      = array_merge( $records, $item_records );
 			do_action( 'algolia_after_get_records', $item );
 
 			$this->update_records( $item, $item_records );


### PR DESCRIPTION
## Description

This PR introduces a fix for deleting of posts — that are created before indexing — from the indices in Algolia.

Fixes: #107