### PR TITLE
fix: avoid 'screen' media attribute

### DIFF
--- a/includes/class-algolia-styles.php
+++ b/includes/class-algolia-styles.php
@@ -37,16 +37,14 @@ class Algolia_Styles {
 			'algolia-autocomplete',
 			ALGOLIA_PLUGIN_URL . 'css/algolia-autocomplete.css',
 			[],
-			ALGOLIA_VERSION,
-			'screen'
+			ALGOLIA_VERSION
 		);
 
 		wp_register_style(
 			'algolia-instantsearch',
 			ALGOLIA_PLUGIN_URL . 'css/algolia-instantsearch.css',
 			[],
-			ALGOLIA_VERSION,
-			'screen'
+			ALGOLIA_VERSION
 		);
 	}
 }


### PR DESCRIPTION
This causes most WordPress optimizer plugins honor the `screen` media attribute and generate a separate CSS for it. We can simply use `all` (default) since we don't have `handheld` or `print` define.

A more details about this issue can be found at https://blog.futtta.be/2016/10/04/how-to-fix-css-media-types-impacting-autoptimized-css-order/