### PR TITLE
Renaming 'blacklist' filters to 'excluded'.

### DIFF
--- a/includes/class-algolia-plugin.php
+++ b/includes/class-algolia-plugin.php
@@ -270,10 +270,10 @@ class Algolia_Plugin {
 		// Add one posts index per post type.
 		$post_types = get_post_types();
 
-		$post_types_blacklist = $this->settings->get_post_types_blacklist();
+		$excluded_post_types = $this->settings->get_excluded_post_types();
 		foreach ( $post_types as $post_type ) {
-			// Skip blacklisted post types.
-			if ( in_array( $post_type, $post_types_blacklist, true ) ) {
+			// Skip excluded post types.
+			if ( in_array( $post_type, $excluded_post_types, true ) ) {
 				continue;
 			}
 
@@ -282,10 +282,10 @@ class Algolia_Plugin {
 
 		// Add one terms index per taxonomy.
 		$taxonomies           = get_taxonomies();
-		$taxonomies_blacklist = $this->settings->get_taxonomies_blacklist();
+		$excluded_taxonomies = $this->settings->get_excluded_taxonomies();
 		foreach ( $taxonomies as $taxonomy ) {
-			// Skip blacklisted post types.
-			if ( in_array( $taxonomy, $taxonomies_blacklist, true ) ) {
+			// Skip excluded taxonomies.
+			if ( in_array( $taxonomy, $excluded_taxonomies, true ) ) {
 				continue;
 			}
 

--- a/includes/class-algolia-settings.php
+++ b/includes/class-algolia-settings.php
@@ -92,31 +92,42 @@ class Algolia_Settings {
 	}
 
 	/**
-	 * Get the post types blacklist.
+	 * Get the excluded post types.
 	 *
 	 * @author  WebDevStudios <contact@webdevstudios.com>
 	 * @since   1.0.0
 	 *
 	 * @return array
 	 */
-	public function get_post_types_blacklist() {
-		$blacklist = (array) apply_filters( 'algolia_post_types_blacklist', array( 'nav_menu_item' ) );
+	public function get_excluded_post_types() {
+
+		// Default array of excluded post types.
+		$excluded = array( 'nav_menu_item' );		
+
+		if ( has_filter( 'algolia_excluded_post_types' ) ) {
+			$excluded = (array) apply_filters( 'algolia_excluded_post_types', $excluded );
+		}
+
+		// Deprecated filter, but will maintain backwards compat.
+		if ( has_filter( 'algolia_post_types_blacklist' ) ) {
+			$excluded = (array) apply_filters( 'algolia_post_types_blacklist', $excluded );
+		}
 
 		// Native WordPress.
-		$blacklist[] = 'revision';
+		$excluded[] = 'revision';
 
 		// Native to Algolia Search plugin.
-		$blacklist[] = 'algolia_task';
-		$blacklist[] = 'algolia_log';
+		$excluded[] = 'algolia_task';
+		$excluded[] = 'algolia_log';
 
 		// Native to WordPress VIP platform.
-		$blacklist[] = 'kr_request_token';
-		$blacklist[] = 'kr_access_token';
-		$blacklist[] = 'deprecated_log';
-		$blacklist[] = 'async-scan-result';
-		$blacklist[] = 'scanresult';
+		$excluded[] = 'kr_request_token';
+		$excluded[] = 'kr_access_token';
+		$excluded[] = 'deprecated_log';
+		$excluded[] = 'async-scan-result';
+		$excluded[] = 'scanresult';
 
-		return array_unique( $blacklist );
+		return array_unique( $excluded );
 	}
 
 	/**
@@ -155,8 +166,21 @@ class Algolia_Settings {
 	 *
 	 * @return array
 	 */
-	public function get_taxonomies_blacklist() {
-		return (array) apply_filters( 'algolia_taxonomies_blacklist', array( 'nav_menu', 'link_category', 'post_format' ) );
+	public function get_excluded_taxonomies() {
+
+		// Default array of excluded taxonomies.
+		$excluded = array( 'nav_menu', 'link_category', 'post_format' );
+
+		if ( has_filter( 'algolia_excluded_taxonomies' ) ) {
+			$excluded = (array) apply_filters( 'algolia_excluded_taxonomies', $excluded );
+		}
+
+		// Deprecated filter, but will maintain backwards compat.
+		if ( has_filter( 'algolia_taxonomies_blacklist' ) ) {
+			$excluded = (array) apply_filters( 'algolia_taxonomies_blacklist', $excluded );
+		}
+
+		return $excluded;
 	}
 
 	/**


### PR DESCRIPTION
While reviewing the available [Filter Hooks](https://github.com/WebDevStudios/wp-search-with-algolia/wiki/Filter-Hooks) I noticed the use of `blacklist` to exclude taxonomies and post types.
This PR addresses this issue while maintaining backwards compat with `algolia_taxonomies_blacklist` and `algolia_post_types_blacklist ` filters that are currently active.

Updated filter examples:
```
function mb_excluded_custom_post_type( array $post_types ) {
	$post_types[] = 'custom_post_type';
	$post_types[] = 'custom_post_type_2';

	return $post_types;
}
add_filter( 'algolia_excluded_post_types', 'mb_excluded_custom_post_type' );
```

```
function mb_excluded_taxonomies( array $taxonomies ) {
	$taxonomies[] = 'custom_tax';
	$taxonomies[] = 'custom_tax_2';

	return $taxonomies;
}
add_filter( 'algolia_excluded_taxonomies', 'mb_excluded_taxonomies' );
```