### PR TITLE
Feature/deprecate blacklist

### DIFF
--- a/includes/class-algolia-plugin.php
+++ b/includes/class-algolia-plugin.php
@@ -270,10 +270,10 @@ class Algolia_Plugin {
 		// Add one posts index per post type.
 		$post_types = get_post_types();
 
-		$post_types_blacklist = $this->settings->get_post_types_blacklist();
+		$excluded_post_types = $this->settings->get_excluded_post_types();
 		foreach ( $post_types as $post_type ) {
-			// Skip blacklisted post types.
-			if ( in_array( $post_type, $post_types_blacklist, true ) ) {
+			// Skip excluded post types.
+			if ( in_array( $post_type, $excluded_post_types, true ) ) {
 				continue;
 			}
 
@@ -282,10 +282,10 @@ class Algolia_Plugin {
 
 		// Add one terms index per taxonomy.
 		$taxonomies           = get_taxonomies();
-		$taxonomies_blacklist = $this->settings->get_taxonomies_blacklist();
+		$excluded_taxonomies = $this->settings->get_excluded_taxonomies();
 		foreach ( $taxonomies as $taxonomy ) {
-			// Skip blacklisted post types.
-			if ( in_array( $taxonomy, $taxonomies_blacklist, true ) ) {
+			// Skip excluded taxonomies.
+			if ( in_array( $taxonomy, $excluded_taxonomies, true ) ) {
 				continue;
 			}
 

--- a/includes/class-algolia-plugin.php
+++ b/includes/class-algolia-plugin.php
@@ -281,7 +281,7 @@ class Algolia_Plugin {
 		}
 
 		// Add one terms index per taxonomy.
-		$taxonomies           = get_taxonomies();
+		$taxonomies          = get_taxonomies();
 		$excluded_taxonomies = $this->settings->get_excluded_taxonomies();
 		foreach ( $taxonomies as $taxonomy ) {
 			// Skip excluded taxonomies.

--- a/includes/class-algolia-settings.php
+++ b/includes/class-algolia-settings.php
@@ -92,31 +92,42 @@ class Algolia_Settings {
 	}
 
 	/**
-	 * Get the post types blacklist.
+	 * Get the excluded post types.
 	 *
 	 * @author  WebDevStudios <contact@webdevstudios.com>
 	 * @since   1.0.0
 	 *
 	 * @return array
 	 */
-	public function get_post_types_blacklist() {
-		$blacklist = (array) apply_filters( 'algolia_post_types_blacklist', array( 'nav_menu_item' ) );
+	public function get_excluded_post_types() {
+
+		// Default array of excluded post types.
+		$excluded = array( 'nav_menu_item' );		
+
+		if ( has_filter( 'algolia_excluded_post_types' ) ) {
+			$excluded = (array) apply_filters( 'algolia_excluded_post_types', $excluded );
+		}
+
+		// Deprecated filter, but will maintain backwards compat.
+		if ( has_filter( 'algolia_post_types_blacklist' ) ) {
+			$excluded = (array) apply_filters( 'algolia_post_types_blacklist', $excluded );
+		}
 
 		// Native WordPress.
-		$blacklist[] = 'revision';
+		$excluded[] = 'revision';
 
 		// Native to Algolia Search plugin.
-		$blacklist[] = 'algolia_task';
-		$blacklist[] = 'algolia_log';
+		$excluded[] = 'algolia_task';
+		$excluded[] = 'algolia_log';
 
 		// Native to WordPress VIP platform.
-		$blacklist[] = 'kr_request_token';
-		$blacklist[] = 'kr_access_token';
-		$blacklist[] = 'deprecated_log';
-		$blacklist[] = 'async-scan-result';
-		$blacklist[] = 'scanresult';
+		$excluded[] = 'kr_request_token';
+		$excluded[] = 'kr_access_token';
+		$excluded[] = 'deprecated_log';
+		$excluded[] = 'async-scan-result';
+		$excluded[] = 'scanresult';
 
-		return array_unique( $blacklist );
+		return array_unique( $excluded );
 	}
 
 	/**
@@ -155,8 +166,21 @@ class Algolia_Settings {
 	 *
 	 * @return array
 	 */
-	public function get_taxonomies_blacklist() {
-		return (array) apply_filters( 'algolia_taxonomies_blacklist', array( 'nav_menu', 'link_category', 'post_format' ) );
+	public function get_excluded_taxonomies() {
+
+		// Default array of excluded taxonomies.
+		$excluded = array( 'nav_menu', 'link_category', 'post_format' );
+
+		if ( has_filter( 'algolia_excluded_taxonomies' ) ) {
+			$excluded = (array) apply_filters( 'algolia_excluded_taxonomies', $excluded );
+		}
+
+		// Deprecated filter, but will maintain backwards compat.
+		if ( has_filter( 'algolia_taxonomies_blacklist' ) ) {
+			$excluded = (array) apply_filters( 'algolia_taxonomies_blacklist', $excluded );
+		}
+
+		return $excluded;
 	}
 
 	/**

--- a/includes/class-algolia-settings.php
+++ b/includes/class-algolia-settings.php
@@ -94,24 +94,59 @@ class Algolia_Settings {
 	/**
 	 * Get the excluded post types.
 	 *
+	 * @author     WebDevStudios <contact@webdevstudios.com>
+	 * @since      1.0.0
+	 * @deprecated 1.7.0 Use Algolia_Settings::get_excluded_post_types()
+	 * @see        Algolia_Settings::get_excluded_post_types()
+	 *
+	 * @return array
+	 */
+	public function get_post_types_blacklist() {
+		_deprecated_function(
+			__METHOD__,
+			'1.7.0',
+			'Algolia_Settings::get_excluded_post_types();'
+		);
+
+		return $this->get_excluded_post_types();
+	}
+
+	/**
+	 * Get the excluded post types.
+	 *
 	 * @author  WebDevStudios <contact@webdevstudios.com>
-	 * @since   1.0.0
+	 * @since   1.7.0
 	 *
 	 * @return array
 	 */
 	public function get_excluded_post_types() {
 
 		// Default array of excluded post types.
-		$excluded = array( 'nav_menu_item' );		
+		$excluded = [ 'nav_menu_item' ];
 
-		if ( has_filter( 'algolia_excluded_post_types' ) ) {
-			$excluded = (array) apply_filters( 'algolia_excluded_post_types', $excluded );
-		}
+		/**
+		 * Filters excluded post types.
+		 *
+		 * @since      1.0.0
+		 * @deprecated 1.7.0 Use {@see 'algolia_excluded_post_types'} instead.
+		 *
+		 * @param array $excluded The excluded post types.
+		 */
+		$excluded = (array) apply_filters_deprecated(
+			'algolia_post_types_blacklist',
+			[ $excluded ],
+			'1.7.0',
+			'algolia_excluded_post_types'
+		);
 
-		// Deprecated filter, but will maintain backwards compat.
-		if ( has_filter( 'algolia_post_types_blacklist' ) ) {
-			$excluded = (array) apply_filters( 'algolia_post_types_blacklist', $excluded );
-		}
+		/**
+		 * Filters excluded post types.
+		 *
+		 * @since 1.7.0
+		 *
+		 * @param array $excluded The excluded post types.
+		 */
+		$excluded = (array) apply_filters( 'algolia_excluded_post_types', $excluded );
 
 		// Native WordPress.
 		$excluded[] = 'revision';
@@ -159,26 +194,58 @@ class Algolia_Settings {
 	}
 
 	/**
-	 * Get taxonomies blacklist.
+	 * Get excluded taxonomies.
 	 *
-	 * @author  WebDevStudios <contact@webdevstudios.com>
-	 * @since   1.0.0
+	 * @author     WebDevStudios <contact@webdevstudios.com>
+	 * @since      1.0.0
+	 * @deprecated 1.7.0 Use Algolia_Settings::get_excluded_taxonomies()
+	 * @see        Algolia_Settings::get_excluded_taxonomies()
+	 *
+	 * @return array
+	 */
+	public function get_taxonomies_blacklist() {
+		_deprecated_function(
+			__METHOD__,
+			'1.7.0',
+			'Algolia_Settings::get_excluded_taxonomies();'
+		);
+
+		return $this->get_excluded_taxonomies();
+	}
+
+	/**
+	 * Get excluded taxonomies.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.7.0
 	 *
 	 * @return array
 	 */
 	public function get_excluded_taxonomies() {
 
 		// Default array of excluded taxonomies.
-		$excluded = array( 'nav_menu', 'link_category', 'post_format' );
+		$excluded = [
+			'nav_menu',
+			'link_category',
+			'post_format',
+		];
 
-		if ( has_filter( 'algolia_excluded_taxonomies' ) ) {
-			$excluded = (array) apply_filters( 'algolia_excluded_taxonomies', $excluded );
-		}
+		/**
+		 * Filters excluded taxonomies.
+		 *
+		 * @since      1.0.0
+		 * @deprecated 1.7.0 Use {@see 'algolia_excluded_taxonomies'} instead.
+		 *
+		 * @param array $excluded The excluded taxonomies.
+		 */
+		$excluded = (array) apply_filters_deprecated(
+			'algolia_taxonomies_blacklist',
+			[ $excluded ],
+			'1.7.0',
+			'algolia_excluded_taxonomies'
+		);
 
-		// Deprecated filter, but will maintain backwards compat.
-		if ( has_filter( 'algolia_taxonomies_blacklist' ) ) {
-			$excluded = (array) apply_filters( 'algolia_taxonomies_blacklist', $excluded );
-		}
+		$excluded = (array) apply_filters( 'algolia_excluded_taxonomies', $excluded );
 
 		return $excluded;
 	}

--- a/includes/class-algolia-styles.php
+++ b/includes/class-algolia-styles.php
@@ -37,16 +37,14 @@ class Algolia_Styles {
 			'algolia-autocomplete',
 			ALGOLIA_PLUGIN_URL . 'css/algolia-autocomplete.css',
 			[],
-			ALGOLIA_VERSION,
-			'screen'
+			ALGOLIA_VERSION
 		);
 
 		wp_register_style(
 			'algolia-instantsearch',
 			ALGOLIA_PLUGIN_URL . 'css/algolia-instantsearch.css',
 			[],
-			ALGOLIA_VERSION,
-			'screen'
+			ALGOLIA_VERSION
 		);
 	}
 }


### PR DESCRIPTION
- fix: Avoid 'screen' media attribute
- update: Rename `blacklist` functions to `excluded`
- update: Throw deprecation warnings for deprecated "blacklist" methods and filters