### PR TITLE
PHP 8.0 Compatibility with changes to usort needing to return integer

### DIFF
--- a/includes/class-algolia-autocomplete-config.php
+++ b/includes/class-algolia-autocomplete-config.php
@@ -74,8 +74,8 @@ class Algolia_Autocomplete_Config {
 		}
 
 		usort(
-			$config, function( $a, $b ) {
-				return $a['position'] > $b['position'];
+			$config, function( $a, $b ):int {
+				return $a['position'] <=> $b['position'];
 			}
 		);
 
@@ -182,8 +182,8 @@ class Algolia_Autocomplete_Config {
 
 		// Sort the indices.
 		usort(
-			$config, function( $a, $b ) {
-				return $a['position'] > $b['position'];
+			$config, function( $a, $b ):int {
+				return $a['position'] <=> $b['position'];
 			}
 		);
 


### PR DESCRIPTION
Just a small fix to enable usort to return -1, 0 or 1 instead of true/false to satisfy upgrade to PHP 8.0