### PR TITLE
Release/1.7.0

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: Search, Algolia, Autocomplete, instant-search, relevant search, search hig
 Requires at least: 5.0
 Tested up to: 5.5
 Requires PHP: 7.2
-Stable tag: 1.6.0
+Stable tag: 1.7.0-dev
 License: GNU General Public License v2.0, MIT License
 
 Improve search on your site. Autocomplete is included, along with full control over look, feel and relevance.
@@ -108,6 +108,14 @@ WebDevStudios provides end-to-end WordPress opportunities from strategy and plan
 == Changelog ==
 
 Follow along with the changelog on [Github](https://github.com/WebDevStudios/wp-search-with-algolia/releases).
+
+= 1.7.0-dev =
+* Remove 'screen' media attribute from enqueued CSS
+* Update Algolia PHP Search Client to version 2.7.3.
+* Add "exclude" methods and filters
+* Deprecate "blacklist" methods and filters
+* Fix replica RequestOptions error
+* Fix PHP 8 usort deprecation warning
 
 = 1.6.0 =
 * Fix deletion of post records created before indexing was enabled

--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Tags: Search, Algolia, Autocomplete, instant-search, relevant search, search hig
 Requires at least: 5.0
 Tested up to: 5.5
 Requires PHP: 7.2
-Stable tag: 1.7.0-dev
+Stable tag: 1.7.0
 License: GNU General Public License v2.0, MIT License
 
 Improve search on your site. Autocomplete is included, along with full control over look, feel and relevance.
@@ -109,7 +109,7 @@ WebDevStudios provides end-to-end WordPress opportunities from strategy and plan
 
 Follow along with the changelog on [Github](https://github.com/WebDevStudios/wp-search-with-algolia/releases).
 
-= 1.7.0-dev =
+= 1.7.0 =
 * Remove 'screen' media attribute from enqueued CSS
 * Update Algolia PHP Search Client to version 2.7.3.
 * Add "exclude" methods and filters
@@ -117,6 +117,7 @@ Follow along with the changelog on [Github](https://github.com/WebDevStudios/wp-
 * Fix replica RequestOptions error
 * Fix PHP 8 usort deprecation warning
 * Fix JQMIGRATE event shorthand is deprecated warnings in instantsearch.php and autocomplete.php templates
+* Add "@version" to template file headers
 
 = 1.6.0 =
 * Fix deletion of post records created before indexing was enabled

--- a/README.txt
+++ b/README.txt
@@ -116,6 +116,7 @@ Follow along with the changelog on [Github](https://github.com/WebDevStudios/wp-
 * Deprecate "blacklist" methods and filters
 * Fix replica RequestOptions error
 * Fix PHP 8 usort deprecation warning
+* Fix JQMIGRATE event shorthand is deprecated warnings in instantsearch.php and autocomplete.php templates
 
 = 1.6.0 =
 * Fix deletion of post records created before indexing was enabled

--- a/algolia.php
+++ b/algolia.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WP Search with Algolia
  * Plugin URI:        https://github.com/WebDevStudios/wp-search-with-algolia
  * Description:       Integrate the powerful Algolia search service with WordPress
- * Version:           1.7.0-dev
+ * Version:           1.7.0
  * Requires at least: 5.0
  * Requires PHP:      7.2
  * Author:            WebDevStudios
@@ -26,7 +26,7 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 // The Algolia Search plugin version.
-define( 'ALGOLIA_VERSION', '1.7.0-dev' );
+define( 'ALGOLIA_VERSION', '1.7.0' );
 
 // The minmum required PHP version.
 define( 'ALGOLIA_MIN_PHP_VERSION', '7.2' );

--- a/algolia.php
+++ b/algolia.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WP Search with Algolia
  * Plugin URI:        https://github.com/WebDevStudios/wp-search-with-algolia
  * Description:       Integrate the powerful Algolia search service with WordPress
- * Version:           1.6.0
+ * Version:           1.7.0-dev
  * Requires at least: 5.0
  * Requires PHP:      7.2
  * Author:            WebDevStudios
@@ -26,7 +26,7 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 // The Algolia Search plugin version.
-define( 'ALGOLIA_VERSION', '1.6.0' );
+define( 'ALGOLIA_VERSION', '1.7.0-dev' );
 
 // The minmum required PHP version.
 define( 'ALGOLIA_MIN_PHP_VERSION', '7.2' );

--- a/composer.lock
+++ b/composer.lock
@@ -137,23 +137,23 @@
     "packages-dev": [
         {
             "name": "algolia/algoliasearch-client-php",
-            "version": "2.7.1",
+            "version": "2.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/algolia/algoliasearch-client-php.git",
-                "reference": "19c0a6c1ef44c0aafaf6c6238c1509ebde2d1a35"
+                "reference": "142a382e4649db0cb64d9eb8893872f1a4ba8dd3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/algolia/algoliasearch-client-php/zipball/19c0a6c1ef44c0aafaf6c6238c1509ebde2d1a35",
-                "reference": "19c0a6c1ef44c0aafaf6c6238c1509ebde2d1a35",
+                "url": "https://api.github.com/repos/algolia/algoliasearch-client-php/zipball/142a382e4649db0cb64d9eb8893872f1a4ba8dd3",
+                "reference": "142a382e4649db0cb64d9eb8893872f1a4ba8dd3",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "ext-json": "*",
                 "ext-mbstring": "*",
-                "php": "^5.3 || ^7.0",
+                "php": "^5.3 || ^7.0 || ^8.0",
                 "psr/http-message": "^1.0",
                 "psr/log": "^1.0",
                 "psr/simple-cache": "^1.0"
@@ -161,7 +161,7 @@
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.0",
                 "fzaninotto/faker": "^1.8",
-                "phpunit/phpunit": "^4.8",
+                "julienbourdeau/phpunit": "4.8.37",
                 "symfony/yaml": "^2.0 || ^4.0"
             },
             "suggest": {
@@ -203,7 +203,7 @@
                 "php",
                 "search"
             ],
-            "time": "2020-11-12T13:52:28+00:00"
+            "time": "2020-12-22T11:27:03+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",

--- a/includes/class-algolia-autocomplete-config.php
+++ b/includes/class-algolia-autocomplete-config.php
@@ -74,8 +74,8 @@ class Algolia_Autocomplete_Config {
 		}
 
 		usort(
-			$config, function( $a, $b ) {
-				return $a['position'] > $b['position'];
+			$config, function( $a, $b ):int {
+				return $a['position'] <=> $b['position'];
 			}
 		);
 
@@ -182,8 +182,8 @@ class Algolia_Autocomplete_Config {
 
 		// Sort the indices.
 		usort(
-			$config, function( $a, $b ) {
-				return $a['position'] > $b['position'];
+			$config, function( $a, $b ):int {
+				return $a['position'] <=> $b['position'];
 			}
 		);
 

--- a/includes/class-algolia-plugin.php
+++ b/includes/class-algolia-plugin.php
@@ -270,10 +270,10 @@ class Algolia_Plugin {
 		// Add one posts index per post type.
 		$post_types = get_post_types();
 
-		$post_types_blacklist = $this->settings->get_post_types_blacklist();
+		$excluded_post_types = $this->settings->get_excluded_post_types();
 		foreach ( $post_types as $post_type ) {
-			// Skip blacklisted post types.
-			if ( in_array( $post_type, $post_types_blacklist, true ) ) {
+			// Skip excluded post types.
+			if ( in_array( $post_type, $excluded_post_types, true ) ) {
 				continue;
 			}
 
@@ -281,11 +281,11 @@ class Algolia_Plugin {
 		}
 
 		// Add one terms index per taxonomy.
-		$taxonomies           = get_taxonomies();
-		$taxonomies_blacklist = $this->settings->get_taxonomies_blacklist();
+		$taxonomies          = get_taxonomies();
+		$excluded_taxonomies = $this->settings->get_excluded_taxonomies();
 		foreach ( $taxonomies as $taxonomy ) {
-			// Skip blacklisted post types.
-			if ( in_array( $taxonomy, $taxonomies_blacklist, true ) ) {
+			// Skip excluded taxonomies.
+			if ( in_array( $taxonomy, $excluded_taxonomies, true ) ) {
 				continue;
 			}
 

--- a/includes/class-algolia-settings.php
+++ b/includes/class-algolia-settings.php
@@ -92,31 +92,77 @@ class Algolia_Settings {
 	}
 
 	/**
-	 * Get the post types blacklist.
+	 * Get the excluded post types.
 	 *
-	 * @author  WebDevStudios <contact@webdevstudios.com>
-	 * @since   1.0.0
+	 * @author     WebDevStudios <contact@webdevstudios.com>
+	 * @since      1.0.0
+	 * @deprecated 1.7.0 Use Algolia_Settings::get_excluded_post_types()
+	 * @see        Algolia_Settings::get_excluded_post_types()
 	 *
 	 * @return array
 	 */
 	public function get_post_types_blacklist() {
-		$blacklist = (array) apply_filters( 'algolia_post_types_blacklist', array( 'nav_menu_item' ) );
+		_deprecated_function(
+			__METHOD__,
+			'1.7.0',
+			'Algolia_Settings::get_excluded_post_types();'
+		);
+
+		return $this->get_excluded_post_types();
+	}
+
+	/**
+	 * Get the excluded post types.
+	 *
+	 * @author  WebDevStudios <contact@webdevstudios.com>
+	 * @since   1.7.0
+	 *
+	 * @return array
+	 */
+	public function get_excluded_post_types() {
+
+		// Default array of excluded post types.
+		$excluded = [ 'nav_menu_item' ];
+
+		/**
+		 * Filters excluded post types.
+		 *
+		 * @since      1.0.0
+		 * @deprecated 1.7.0 Use {@see 'algolia_excluded_post_types'} instead.
+		 *
+		 * @param array $excluded The excluded post types.
+		 */
+		$excluded = (array) apply_filters_deprecated(
+			'algolia_post_types_blacklist',
+			[ $excluded ],
+			'1.7.0',
+			'algolia_excluded_post_types'
+		);
+
+		/**
+		 * Filters excluded post types.
+		 *
+		 * @since 1.7.0
+		 *
+		 * @param array $excluded The excluded post types.
+		 */
+		$excluded = (array) apply_filters( 'algolia_excluded_post_types', $excluded );
 
 		// Native WordPress.
-		$blacklist[] = 'revision';
+		$excluded[] = 'revision';
 
 		// Native to Algolia Search plugin.
-		$blacklist[] = 'algolia_task';
-		$blacklist[] = 'algolia_log';
+		$excluded[] = 'algolia_task';
+		$excluded[] = 'algolia_log';
 
 		// Native to WordPress VIP platform.
-		$blacklist[] = 'kr_request_token';
-		$blacklist[] = 'kr_access_token';
-		$blacklist[] = 'deprecated_log';
-		$blacklist[] = 'async-scan-result';
-		$blacklist[] = 'scanresult';
+		$excluded[] = 'kr_request_token';
+		$excluded[] = 'kr_access_token';
+		$excluded[] = 'deprecated_log';
+		$excluded[] = 'async-scan-result';
+		$excluded[] = 'scanresult';
 
-		return array_unique( $blacklist );
+		return array_unique( $excluded );
 	}
 
 	/**
@@ -148,15 +194,60 @@ class Algolia_Settings {
 	}
 
 	/**
-	 * Get taxonomies blacklist.
+	 * Get excluded taxonomies.
 	 *
-	 * @author  WebDevStudios <contact@webdevstudios.com>
-	 * @since   1.0.0
+	 * @author     WebDevStudios <contact@webdevstudios.com>
+	 * @since      1.0.0
+	 * @deprecated 1.7.0 Use Algolia_Settings::get_excluded_taxonomies()
+	 * @see        Algolia_Settings::get_excluded_taxonomies()
 	 *
 	 * @return array
 	 */
 	public function get_taxonomies_blacklist() {
-		return (array) apply_filters( 'algolia_taxonomies_blacklist', array( 'nav_menu', 'link_category', 'post_format' ) );
+		_deprecated_function(
+			__METHOD__,
+			'1.7.0',
+			'Algolia_Settings::get_excluded_taxonomies();'
+		);
+
+		return $this->get_excluded_taxonomies();
+	}
+
+	/**
+	 * Get excluded taxonomies.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.7.0
+	 *
+	 * @return array
+	 */
+	public function get_excluded_taxonomies() {
+
+		// Default array of excluded taxonomies.
+		$excluded = [
+			'nav_menu',
+			'link_category',
+			'post_format',
+		];
+
+		/**
+		 * Filters excluded taxonomies.
+		 *
+		 * @since      1.0.0
+		 * @deprecated 1.7.0 Use {@see 'algolia_excluded_taxonomies'} instead.
+		 *
+		 * @param array $excluded The excluded taxonomies.
+		 */
+		$excluded = (array) apply_filters_deprecated(
+			'algolia_taxonomies_blacklist',
+			[ $excluded ],
+			'1.7.0',
+			'algolia_excluded_taxonomies'
+		);
+
+		$excluded = (array) apply_filters( 'algolia_excluded_taxonomies', $excluded );
+
+		return $excluded;
 	}
 
 	/**

--- a/includes/class-algolia-styles.php
+++ b/includes/class-algolia-styles.php
@@ -37,16 +37,14 @@ class Algolia_Styles {
 			'algolia-autocomplete',
 			ALGOLIA_PLUGIN_URL . 'css/algolia-autocomplete.css',
 			[],
-			ALGOLIA_VERSION,
-			'screen'
+			ALGOLIA_VERSION
 		);
 
 		wp_register_style(
 			'algolia-instantsearch',
 			ALGOLIA_PLUGIN_URL . 'css/algolia-instantsearch.css',
 			[],
-			ALGOLIA_VERSION,
-			'screen'
+			ALGOLIA_VERSION
 		);
 	}
 }

--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -731,7 +731,7 @@ abstract class Algolia_Index {
 		$this->get_index()->setSettings(
 			array(
 				'replicas' => $replica_index_names,
-			), false
+			)
 		);
 
 		$client = $this->get_client();

--- a/includes/libraries/algoliasearch-client-php/.circleci/config.yml
+++ b/includes/libraries/algoliasearch-client-php/.circleci/config.yml
@@ -1,0 +1,151 @@
+# PHP CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-php/ for more details
+#
+version: 2.1
+
+
+executors:
+  php-docker: # declares a reusable executor
+    parameters:
+      version:
+        description: "PHP version tag"
+        type: string
+    docker:
+        - image: circleci/php:<<parameters.version>>
+
+jobs:
+  test:
+    parameters:
+      version:
+        description: "PHP version tag"
+        type: string
+      http_client:
+        description: "PHP Client"
+        type: string
+
+    executor:
+      name: php-docker
+      version: <<parameters.version>>
+
+    steps:
+      - checkout
+
+      - run: sudo apt update
+      - run: sudo docker-php-ext-install zip
+
+      # Download and cache dependencies
+#      - restore_cache:
+#          keys:
+#            - composer-deps-<<parameters.version>>-{{ checksum "composer.json" }}
+#            # fallback to using the latest cache if no exact match is found
+#            #- composer-deps-
+
+      - run: COMPOSER_MEMORY_LIMIT=-1 composer install -n --prefer-dist
+
+#      - save_cache:
+#          key: composer-deps-<<parameters.version>>-{{ checksum "composer.json" }}
+#          paths:
+#            - ./vendor
+
+      - run:
+          name: Install PHP Client
+          command: |
+            if [ "<<parameters.http_client>>" == "legacy" ]
+            then
+               echo "Nothing to install, using default Algolia\AlgoliaSearch\Http\Php53HttpClient"
+            else
+              COMPOSER_MEMORY_LIMIT=-1 composer require <<parameters.http_client>>
+            fi
+
+      - run:
+          name: Get API Key Dealer client
+          command: wget https://alg.li/algolia-keys && chmod +x algolia-keys
+
+#      - run:
+#          name: Check code styles
+#          command: vendor/bin/php-cs-fixer fix -v --dry-run
+
+      # Run tests with phpunit
+      #
+      # If the PR is open by an Algolia, we run all the tests
+      # with the keys in the env variables
+      # If the PR was open from a fork (community PR)
+      # we get API keys from the API key dealer https://alg.li/api-key-dealer
+      - run:
+          name: Run tests
+          command: |
+            export CI_BUILD_NUM=$CIRCLE_BUILD_NUM
+            if [ -z ${CIRCLE_PR_REPONAME+x} ]
+            then
+               php vendor/bin/phpunit
+            else
+              export CI_PROJ_USERNAME=$CIRCLE_PR_USERNAME
+              export CI_PROJ_REPONAME=$CIRCLE_PR_REPONAME
+
+              eval $(./algolia-keys export)
+              php vendor/bin/phpunit -v --testsuite Unit,Definition,Community
+            fi
+
+      - run:
+          name: Autoloading without Composer
+          command: php tests/tests-no-composer.php
+
+
+workflows:
+  workflow:
+    jobs:
+      - test:
+          name: 'Guzzle 7 - PHP latest'
+          version: "latest"
+          http_client: guzzlehttp/guzzle:"^7.0"
+      - test:
+          name: 'Guzzle 7 - PHP 8.0'
+          version: "8.0"
+          http_client: guzzlehttp/guzzle:"^7.0"
+      - test:
+          name: 'Guzzle 7 - PHP 7.4'
+          version: "7.4"
+          http_client: guzzlehttp/guzzle:"^7.0"
+
+      - test:
+          name: 'Guzzle 6 - PHP latest'
+          version: "latest"
+          http_client: guzzlehttp/guzzle:"^6.0"
+      - test:
+          name: 'Guzzle 6 - PHP 8.0'
+          version: "8.0"
+          http_client: guzzlehttp/guzzle:"^6.0"
+      - test:
+          name: 'Guzzle 6 - PHP 7.4'
+          version: "7.4"
+          http_client: guzzlehttp/guzzle:"^6.0"
+      - test:
+          name: 'Guzzle 6 - PHP 7.0'
+          version: "7.0"
+          http_client: guzzlehttp/guzzle:"^6.0"
+      - test:
+          name: 'Guzzle 6 - PHP 5.6'
+          version: "5.6"
+          http_client: guzzlehttp/guzzle:"^6.0"
+
+      - test:
+          name: 'Legacy client - PHP latest'
+          version: "latest"
+          http_client: legacy
+      - test:
+          name: 'Legacy client - PHP 8.0'
+          version: "8.0"
+          http_client: legacy
+      - test:
+          name: 'Legacy client - PHP 7.4'
+          version: "7.4"
+          http_client: legacy
+      - test:
+          name: 'Legacy client - PHP 7.0'
+          version: "7.0"
+          http_client: legacy
+      - test:
+          name: 'Legacy client - PHP 5.6'
+          version: "5.6"
+          http_client: legacy

--- a/includes/libraries/algoliasearch-client-php/.circleci/index-cleanup.php
+++ b/includes/libraries/algoliasearch-client-php/.circleci/index-cleanup.php
@@ -1,0 +1,19 @@
+<?php
+
+require '../vendor/autoload.php';
+
+$client = Algolia\AlgoliaSearch\SearchClient::create("I2UB5B7IZB", getenv('ALGOLIA_API_KEY'));
+
+$indices = $client->listIndices();
+
+foreach(array_chunk($indices['items'], 100) as $chunk) {
+    $ops = array();
+    foreach($chunk as $index) {
+        array_push($ops, [
+            'indexName' => $index['name'],
+            'action' => 'delete',
+        ]);
+    }
+
+    $client->multipleBatch($ops);
+}

--- a/includes/libraries/algoliasearch-client-php/.dockerignore
+++ b/includes/libraries/algoliasearch-client-php/.dockerignore
@@ -1,0 +1,5 @@
+.php_cs.cache
+/tests/cache/
+.idea/
+.php_cs.dist
+/vendor/

--- a/includes/libraries/algoliasearch-client-php/DOCKER_README.MD
+++ b/includes/libraries/algoliasearch-client-php/DOCKER_README.MD
@@ -1,0 +1,81 @@
+In this page you will find our recommended way of installing Docker on your machine. 
+This guide is made for OSX users.
+
+## Install docker
+
+First install Docker using [Homebrew](https://brew.sh/)
+```
+$ brew install docker
+```
+
+You can then install [Docker Desktop](https://docs.docker.com/get-docker/) if you wish, or use `docker-machine`. As we prefer the second option, we will only document this one.
+
+## Setup your docker
+
+Install `docker-machine`
+```
+$ brew install docker-machine
+```
+
+Then install [VirtualBox](https://www.virtualbox.org/) with [Homebrew Cask](https://github.com/Homebrew/homebrew-cask) to get a driver for your Docker machine
+```
+$ brew cask install virtualbox
+```
+
+You may need to enter your password and authorize the application in your `System Settings` > `Security & Privacy`.
+
+Create now a new machine, set it up as default and connect your shell to it (here we use zsh. The commands should anyway be displayed in each steps' output)
+
+```
+$ docker-machine create --driver virtualbox default
+$ docker-machine env default
+$ eval "$(docker-machine env default)"
+```
+
+Now you're all setup to use our provided Docker image!
+
+## Build the image
+
+```bash
+docker build -t algolia-php .
+```
+
+## Run the image
+
+You need to provide few environment variables at runtime to be able to run the [Common Test Suite](https://github.com/algolia/algoliasearch-client-specs/tree/master/common-test-suite).
+You can set them up directly in the command:
+
+```bash
+docker run -it --rm --env ALGOLIA_APP_ID=XXXXXX [...] -v $PWD:/app -w /app algolia-php bash
+```
+
+However, we advise you to export them in your `.bashrc` or `.zshrc`. That way, you can use [Docker's shorten syntax](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file) to set your variables.
+
+```bash
+docker run -it --rm --env ALGOLIA_APP_ID \
+                    --env ALGOLIA_API_KEY \
+-v $PWD:/app -w /app algolia-php bash
+
+### This is needed only to run the full test suite
+docker run -it --rm --env ALGOLIA_APP_ID \
+                    --env ALGOLIA_API_KEY \
+                    --env ALGOLIA_APPLICATION_ID_MCM \
+                    --env ALGOLIA_ADMIN_KEY_MCM \
+-v $PWD:/app -w /app algolia-php bash
+```
+
+Once your container is running, any changes you make in your IDE are directly reflected in the container.
+
+To launch the tests, you can use one of the following commands
+```shell script
+# run only the unit tests
+./vendor/bin/phpunit
+
+# run a single test
+./vendor/bin/phpunit --filter=nameOfYourTests
+```
+
+You can find more commands in the `composer.json` file.
+
+Feel free to contact us if you have any questions.
+

--- a/includes/libraries/algoliasearch-client-php/Dockerfile
+++ b/includes/libraries/algoliasearch-client-php/Dockerfile
@@ -1,0 +1,18 @@
+# Dockerfile
+FROM php:7.4.1-fpm
+
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        wget \
+        zip \
+        unzip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Composer
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+WORKDIR /app
+ADD . /app/
+
+RUN composer install

--- a/includes/libraries/algoliasearch-client-php/composer.json
+++ b/includes/libraries/algoliasearch-client-php/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": "^5.3 || ^7.0 || ^8.0",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
@@ -22,7 +22,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",
         "fzaninotto/faker": "^1.8",
-        "phpunit/phpunit": "^4.8",
+        "julienbourdeau/phpunit": "4.8.37",
         "symfony/yaml": "^2.0 || ^4.0"
     },
     "autoload": {

--- a/includes/libraries/algoliasearch-client-php/src/Algolia.php
+++ b/includes/libraries/algoliasearch-client-php/src/Algolia.php
@@ -10,7 +10,7 @@ use Psr\SimpleCache\CacheInterface;
 
 final class Algolia
 {
-    const VERSION = '2.7.1';
+    const VERSION = '2.7.3';
 
     /**
      * Holds an instance of the simple cache repository (PSR-16).

--- a/templates/autocomplete.php
+++ b/templates/autocomplete.php
@@ -5,6 +5,7 @@
  * @author  WebDevStudios <contact@webdevstudios.com>
  * @since   1.0.0
  *
+ * @version 1.7.0
  * @package WebDevStudios\WPSWA
  */
 

--- a/templates/autocomplete.php
+++ b/templates/autocomplete.php
@@ -174,7 +174,7 @@
 				} );
 
 			/* Force the dropdown to be re-drawn on scroll to handle fixed containers. */
-			jQuery( window ).scroll( function () {
+			jQuery( window ).on( 'scroll', function() {
 				if ( autocomplete.autocomplete.getWrapper().style.display === "block" ) {
 					autocomplete.autocomplete.close();
 					autocomplete.autocomplete.open();

--- a/templates/instantsearch.php
+++ b/templates/instantsearch.php
@@ -191,7 +191,7 @@ get_header();
 				/* Start */
 				search.start();
 
-				jQuery('#algolia-search-box input').attr('type', 'search').select();
+				jQuery( '#algolia-search-box input' ).attr( 'type', 'search' ).trigger( 'select' );
 			}
 		});
 	</script>

--- a/templates/instantsearch.php
+++ b/templates/instantsearch.php
@@ -5,6 +5,7 @@
  * @author  WebDevStudios <contact@webdevstudios.com>
  * @since   1.0.0
  *
+ * @version 1.7.0
  * @package WebDevStudios\WPSWA
  */
 
@@ -73,8 +74,8 @@ get_header();
 					},
 					searchParameters: {
 						facetingAfterDistinct: true,
-			highlightPreTag: '__ais-highlight__',
-			highlightPostTag: '__/ais-highlight__'
+						highlightPreTag: '__ais-highlight__',
+						highlightPostTag: '__/ais-highlight__'
 					}
 				});
 


### PR DESCRIPTION
- Remove 'screen' media attribute from enqueued CSS
- Update Algolia PHP Search Client to version 2.7.3.
- Add "exclude" methods and filters
- Deprecate "blacklist" methods and filters
- Fix replica RequestOptions error
- Fix PHP 8 usort deprecation warning
- Fix JQMIGRATE event shorthand is deprecated warnings in instantsearch.php and autocomplete.php templates
- Add "@version" to template file headers
