### PR TITLE
#137 Feature/template utilities

### DIFF
--- a/classmap.php
+++ b/classmap.php
@@ -44,6 +44,8 @@ require_once ALGOLIA_PATH . 'includes/watchers/class-algolia-post-changes-watche
 require_once ALGOLIA_PATH . 'includes/watchers/class-algolia-term-changes-watcher.php';
 require_once ALGOLIA_PATH . 'includes/watchers/class-algolia-user-changes-watcher.php';
 
+require_once ALGOLIA_PATH . 'includes/utilities/class-algolia-template-utils.php';
+
 if ( is_admin() ) {
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin.php';
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin-page-autocomplete.php';

--- a/includes/class-algolia-plugin.php
+++ b/includes/class-algolia-plugin.php
@@ -394,13 +394,23 @@ class Algolia_Plugin {
 	/**
 	 * Get the templates path.
 	 *
-	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  1.0.0
+	 * Somewhat misleading method name.
+	 * Actually returns a path segment (directory name) with trailing slash.
+	 *
+	 * @author     WebDevStudios <contact@webdevstudios.com>
+	 * @since      1.0.0
+	 * @deprecated 1.8.0-dev Use Algolia_Template_Utils::get_filtered_theme_templates_dirname()
+	 * @see        Algolia_Template_Utils::get_filtered_theme_templates_dirname()
 	 *
 	 * @return string
 	 */
 	public function get_templates_path() {
-		return (string) apply_filters( 'algolia_templates_path', 'algolia/' );
+		_deprecated_function(
+			__METHOD__,
+			'1.8.0-dev',
+			'Algolia_Template_Utils::get_filtered_theme_templates_dirname()'
+		);
+		return (string) Algolia_Template_Utils::get_filtered_theme_templates_dirname();
 	}
 
 	/**

--- a/includes/class-algolia-template-loader.php
+++ b/includes/class-algolia-template-loader.php
@@ -156,8 +156,8 @@ class Algolia_Template_Loader {
 	 *
 	 * Handles template usage so that we can use our own templates instead of the themes.
 	 *
-	 * Templates are in the 'templates' folder. algolia looks for theme.
-	 * overrides in /your-theme/algolia/ by default.
+	 * Plugin templates are located in the 'templates' directory.
+	 * Customized templates are in the theme's 'algolia' directory.
 	 *
 	 * @author  WebDevStudios <contact@webdevstudios.com>
 	 * @since   1.0.0

--- a/includes/class-algolia-template-loader.php
+++ b/includes/class-algolia-template-loader.php
@@ -198,7 +198,7 @@ class Algolia_Template_Loader {
 			}
 		);
 
-		return $this->locate_template( 'instantsearch.php' );
+		return Algolia_Template_Utils::locate_template( 'instantsearch.php' );
 	}
 
 	/**

--- a/includes/class-algolia-template-loader.php
+++ b/includes/class-algolia-template-loader.php
@@ -214,29 +214,21 @@ class Algolia_Template_Loader {
 	/**
 	 * Locate a template.
 	 *
-	 * @author  WebDevStudios <contact@webdevstudios.com>
-	 * @since   1.0.0
+	 * @author     WebDevStudios <contact@webdevstudios.com>
+	 * @since      1.0.0
+	 * @deprecated 1.8.0-dev Use Algolia_Template_Utils::locate_template()
+	 * @see        Algolia_Template_Utils::locate_template()
 	 *
 	 * @param string $file The template file.
 	 *
 	 * @return string
 	 */
 	private function locate_template( $file ) {
-		$locations[] = $file;
-
-		$templates_path = $this->plugin->get_templates_path();
-		if ( 'algolia/' !== $templates_path ) {
-			$locations[] = 'algolia/' . $file;
-		}
-
-		$locations[] = $templates_path . $file;
-
-		$locations = (array) apply_filters( 'algolia_template_locations', $locations, $file );
-
-		$template = locate_template( array_unique( $locations ) );
-
-		$default_template = (string) apply_filters( 'algolia_default_template', $this->plugin->get_path() . '/templates/' . $file, $file );
-
-		return $template ? $template : $default_template;
+		_deprecated_function(
+			__METHOD__,
+			'1.8.0-dev',
+			'Algolia_Template_Utils::locate_template()'
+		);
+		return Algolia_Template_Utils::locate_template( $file );
 	}
 }

--- a/includes/class-algolia-template-loader.php
+++ b/includes/class-algolia-template-loader.php
@@ -206,9 +206,11 @@ class Algolia_Template_Loader {
 	 *
 	 * @author  WebDevStudios <contact@webdevstudios.com>
 	 * @since   1.0.0
+	 *
+	 * @return string
 	 */
 	public function load_autocomplete_template() {
-		require $this->locate_template( 'autocomplete.php' );
+		return Algolia_Template_Utils::locate_template( 'autocomplete.php' );
 	}
 
 	/**

--- a/includes/class-algolia-template-loader.php
+++ b/includes/class-algolia-template-loader.php
@@ -206,11 +206,9 @@ class Algolia_Template_Loader {
 	 *
 	 * @author  WebDevStudios <contact@webdevstudios.com>
 	 * @since   1.0.0
-	 *
-	 * @return string
 	 */
 	public function load_autocomplete_template() {
-		return Algolia_Template_Utils::locate_template( 'autocomplete.php' );
+		require Algolia_Template_Utils::locate_template( 'autocomplete.php' );
 	}
 
 	/**

--- a/includes/utilities/class-algolia-template-utils.php
+++ b/includes/utilities/class-algolia-template-utils.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * Algolia_Template_Utils class file.
+ *
+ * @since   1.8.0-dev
+ * @package WebDevStudios\WPSWA
+ */
+
+/**
+ * Class Algolia_Template_Utils
+ *
+ * @since 1.8.0-dev
+ */
+class Algolia_Template_Utils {
+
+	/**
+	 * The plugin template directory name.
+	 *
+	 * @since 1.8.0-dev
+	 *
+	 * @var string
+	 */
+	const TEMPLATES_DIR = 'templates';
+
+	/**
+	 * The theme template directory name.
+	 *
+	 * @since 1.8.0-dev
+	 *
+	 * @var string
+	 */
+	const THEME_TEMPLATES_DIR = 'algolia';
+
+	/**
+	 * Get the plugin templates directory with trailing slash.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @return string The plugin templates directory name with trailing slash.
+	 */
+	public static function get_plugin_templates_dirname() {
+		return (string) self::TEMPLATES_DIR . '/';
+	}
+
+	/**
+	 * Get the "unfiltered" theme templates directory with trailing slash.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @return string The theme templates directory name with trailing slash.
+	 */
+	public static function get_theme_templates_dirname() {
+		return (string) self::THEME_TEMPLATES_DIR . '/';
+	}
+
+	/**
+	 * Get the "filtered" theme templates directory with trailing slash.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @return string The theme templates directory name with trailing slash.
+	 */
+	public static function get_filtered_theme_templates_dirname() {
+
+		/**
+		 * Allow developers to override the theme templates dirname.
+		 *
+		 * @since  1.8.0-dev
+		 *
+		 * @param string $path The theme templates directory name with trailing slash.
+		 *                     Defaults to 'algolia/'.
+		 */
+		return (string) apply_filters(
+			'algolia_theme_templates_dirname',
+			self::get_theme_templates_dirname()
+		);
+	}
+
+	/**
+	 * Get the "unfiltered" full path to the default template file in the plugin.
+	 *
+	 * @author  WebDevStudios <contact@webdevstudios.com>
+	 * @since   1.8.0-dev
+	 *
+	 * @param string $file The template filename.
+	 *
+	 * @return string Full path to the template file.
+	 */
+	public static function get_default_template( $file ) {
+		return (string) ALGOLIA_PATH . self::get_plugin_templates_dirname() . $file;
+	}
+
+	/**
+	 * Get the "filtered" full path to the default template file in the plugin.
+	 *
+	 * @author  WebDevStudios <contact@webdevstudios.com>
+	 * @since   1.8.0-dev
+	 *
+	 * @param string $file The template filename.
+	 *
+	 * @return string Full path to the template file.
+	 */
+	public static function get_filtered_default_template( $file ) {
+		/**
+		 * Allow developers to override the default template.
+		 *
+		 * @todo Should this even be allowed?
+		 *
+		 * @since  1.0.0
+		 *
+		 * @param string $template Full path to the default template file.
+		 * @param string $file     The default template file.
+		 */
+		return (string) apply_filters(
+			'algolia_default_template',
+			self::get_default_template( $file ),
+			$file
+		);
+	}
+
+	/**
+	 * Locate a template.
+	 *
+	 * @author  WebDevStudios <contact@webdevstudios.com>
+	 * @since   1.8.0-dev
+	 *
+	 * @param string $file The template file.
+	 *
+	 * @return string Full path to the template file.
+	 */
+	public static function locate_template( $file ) {
+
+		$locations = [
+			$file,
+		];
+
+		$templates_path = self::get_filtered_theme_templates_dirname();
+
+		if ( self::get_theme_templates_dirname() !== $templates_path ) {
+			$locations[] = self::get_theme_templates_dirname() . $file;
+		}
+
+		$locations[] = $templates_path . $file;
+
+		/**
+		 * Allow developers to override the template locations.
+		 *
+		 * @todo Should this even be allowed?
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param array  $locations Array of template locations.
+		 * @param string $file      The template file.
+		 */
+		$locations = (array) apply_filters(
+			'algolia_template_locations',
+			$locations,
+			$file
+		);
+
+		$template = locate_template(
+			array_unique( $locations )
+		);
+
+		$filtered_default = self::get_filtered_default_template( $file );
+
+		return (string) $template ? $template : $filtered_default;
+	}
+
+	/**
+	 * Retrieve template version.
+	 *
+	 * Based on WooCommerce's WC_Admin_Status::get_file_version() method.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @param string $template Full path to the template file.
+	 *
+	 * @return string
+	 */
+	public static function get_version( $template ): ?string {
+
+		// Null, if template file does not exist or cannot be read.
+		if ( ! is_file( $template ) || ! is_readable( $template ) ) {
+			return null;
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen
+		$pointer = fopen( $template, 'r' );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fread
+		$file_data = fread( $pointer, 8192 );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose
+		fclose( $pointer );
+
+		$file_data = str_replace( "\r", "\n", $file_data );
+
+		// Empty string, if version cannot be determined.
+		$version = '';
+
+		preg_match(
+			'/^[ \t\/*#@]*' . preg_quote( '@version', '/' ) . '(.*)$/mi',
+			$file_data,
+			$matches
+		);
+
+		if ( empty( $matches[1] ) ) {
+			return $version;
+		}
+
+		return _cleanup_header_comment( $matches[1] );
+	}
+}

--- a/includes/utilities/class-algolia-template-utils.php
+++ b/includes/utilities/class-algolia-template-utils.php
@@ -20,7 +20,7 @@ class Algolia_Template_Utils {
 	 *
 	 * @var string
 	 */
-	const TEMPLATES_DIR = 'templates';
+	const PLUGIN_TEMPLATES_DIR = 'templates';
 
 	/**
 	 * The theme template directory name.
@@ -40,7 +40,7 @@ class Algolia_Template_Utils {
 	 * @return string The plugin templates directory name with trailing slash.
 	 */
 	public static function get_plugin_templates_dirname() {
-		return (string) self::TEMPLATES_DIR . '/';
+		return (string) self::PLUGIN_TEMPLATES_DIR . '/';
 	}
 
 	/**

--- a/includes/utilities/class-algolia-template-utils.php
+++ b/includes/utilities/class-algolia-template-utils.php
@@ -56,7 +56,7 @@ class Algolia_Template_Utils {
 	}
 
 	/**
-	 * Get the "filtered" theme templates directory with trailing slash.
+	 * Get the "filtered" theme templates directory name with trailing slash.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
 	 * @since  1.8.0-dev
@@ -64,6 +64,24 @@ class Algolia_Template_Utils {
 	 * @return string The theme templates directory name with trailing slash.
 	 */
 	public static function get_filtered_theme_templates_dirname() {
+
+		$path = self::get_theme_templates_dirname();
+
+		/**
+		 * Allow developers to override the theme templates dirname.
+		 *
+		 * @since      1.0.0
+		 * @deprecated 1.8.0-dev Use {@see 'algolia_theme_templates_dirname'} instead.
+		 *
+		 * @param string $path The theme templates directory name with trailing slash.
+		 *                     Defaults to 'algolia/'.
+		 */
+		$path = (string) apply_filters_deprecated(
+			'algolia_templates_path',
+			[ $path ],
+			'1.8.0-dev',
+			'algolia_theme_templates_dirname'
+		);
 
 		/**
 		 * Allow developers to override the theme templates dirname.
@@ -75,7 +93,7 @@ class Algolia_Template_Utils {
 		 */
 		return (string) apply_filters(
 			'algolia_theme_templates_dirname',
-			self::get_theme_templates_dirname()
+			$path
 		);
 	}
 


### PR DESCRIPTION
Per #137

Start breaking some of the template responsibilities out into a Utilities class.
This is prep work for comparing customized template versions against versions that ship with the plugin.
This will be used for admin notices that warn users if their customized template versions are out of date.

- Add Algolia_Template_Utils class
- Rename TEMPLATES_DIR to PLUGIN_TEMPLATES_DIR
- Require the Algolia_Template_Utils file
- Deprecate Algolia_Template_Loader::locate_template and return Algolia_Template_Utils::locate_template
- Return Algolia_Template_Utils::locate_template in Algolia_Template_Loader::load_autocomplete_template
- Return Algolia_Template_Utils::locate_template in Algolia_Template_Loader::load_instantsearch_template
- Clarify template locations in Algolia_Template_Loader::template_loader docblock
- Deprecate algolia_templates_path filter
- Deprecate Algolia_Plugin::get_templates_path method
- Algolia_Template_Loader::load_autocomplete_template should require not return
