### PR TITLE
Add utility methods to get the core templates, located templates, and customized templates

### DIFF
--- a/classmap.php
+++ b/classmap.php
@@ -45,10 +45,12 @@ require_once ALGOLIA_PATH . 'includes/watchers/class-algolia-term-changes-watche
 require_once ALGOLIA_PATH . 'includes/watchers/class-algolia-user-changes-watcher.php';
 
 require_once ALGOLIA_PATH . 'includes/utilities/class-algolia-template-utils.php';
+require_once ALGOLIA_PATH . 'includes/utilities/class-algolia-version-utils.php';
 
 if ( is_admin() ) {
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin.php';
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin-page-autocomplete.php';
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin-page-native-search.php';
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin-page-settings.php';
+	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin-notices.php';
 }

--- a/classmap.php
+++ b/classmap.php
@@ -52,5 +52,5 @@ if ( is_admin() ) {
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin-page-autocomplete.php';
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin-page-native-search.php';
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin-page-settings.php';
-	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin-notices.php';
+	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin-template-notices.php';
 }

--- a/includes/admin/class-algolia-admin-template-notices.php
+++ b/includes/admin/class-algolia-admin-template-notices.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Algolia_Admin_Template_Notices class file.
+ *
+ * @author  WebDevStudios <contact@webdevstudios.com>
+ * @since   1.8.0-dev
+ *
+ * @package WebDevStudios\WPSWA
+ */
+
+/**
+ * Class Algolia_Admin_Template_Notices
+ *
+ * @since 1.8.0-dev
+ */
+class Algolia_Admin_Template_Notices {
+
+	/**
+	 * Algolia_Admin_Template_Notices constructor.
+	 *
+	 * @author  WebDevStudios <contact@webdevstudios.com>
+	 * @since   1.8.0-dev
+	 */
+	public function __construct() {
+		add_action( 'admin_notices', [ $this, 'template_version_notices' ] );
+	}
+
+	/**
+	 * Display template version discrepencany notices.
+	 *
+	 * @author  WebDevStudios <contact@webdevstudios.com>
+	 * @since   1.8.0-dev
+	 *
+	 * @return void
+	 */
+	public function template_version_notices() {
+
+		$core_template_paths = Algolia_Template_Utils::get_core_template_paths();
+
+		$custom_template_paths = Algolia_Template_Utils::get_custom_template_paths();
+
+		if ( empty( $custom_template_paths ) ) {
+			return;
+		}
+
+		$core_template_versions = [];
+
+		$custom_template_versions = [];
+
+		foreach ( $custom_template_paths as $filename => $file_path ) {
+			$core_template_versions[ $filename ]   = Algolia_Template_Utils::get_template_version(
+				$core_template_paths[ $filename ]
+			);
+			$custom_template_versions[ $filename ] = Algolia_Template_Utils::get_template_version(
+				$file_path
+			);
+		}
+
+		foreach ( $custom_template_versions as $filename => $file_version ) {
+
+			$core_major_version = Algolia_Version_Utils::get_major_version(
+				$core_template_versions[ $filename ]
+			);
+
+			$custom_major_version = Algolia_Version_Utils::get_major_version(
+				$file_version
+			);
+
+			// Error if MAJOR version does not match, or custom template version unknown.
+			if ( $custom_major_version !== $core_major_version ) {
+				$error_notices[] = sprintf(
+					/* translators: placeholder 1 is template filename, placeholder 2 is custom template version, placeholder 3 is core template version. */
+					esc_html__(
+						'Your custom WP Search With Algolia template file, %1$s, version %2$s is out of date. The core version is %3$s',
+						'wp-search-with-algolia'
+					),
+					$filename,
+					! empty( $file_version ) ? $file_version : __( 'unknown', 'wp-search-with-algolia' ),
+					$core_template_versions[ $filename ]
+				);
+			}
+		}
+
+		if ( empty( $error_notices ) ) {
+			return;
+		}
+
+		foreach ( $error_notices as $error_notice ) {
+			echo '<div class="notice notice-error"><p>' . esc_html( $error_notice ) . '</p></div>';
+		}
+	}
+}

--- a/includes/admin/class-algolia-admin-template-notices.php
+++ b/includes/admin/class-algolia-admin-template-notices.php
@@ -57,17 +57,8 @@ class Algolia_Admin_Template_Notices {
 		}
 
 		foreach ( $custom_template_versions as $filename => $file_version ) {
-
-			$core_major_version = Algolia_Version_Utils::get_major_version(
-				$core_template_versions[ $filename ]
-			);
-
-			$custom_major_version = Algolia_Version_Utils::get_major_version(
-				$file_version
-			);
-
-			// Error if MAJOR version does not match, or custom template version unknown.
-			if ( $custom_major_version !== $core_major_version ) {
+			// Error if versions do not match, or custom template version unknown.
+			if ( version_compare( $file_version, $core_template_versions[ $filename ], '!=' ) ) {
 				$error_notices[] = sprintf(
 					/* translators: placeholder 1 is template filename, placeholder 2 is custom template version, placeholder 3 is core template version. */
 					esc_html__(

--- a/includes/admin/class-algolia-admin.php
+++ b/includes/admin/class-algolia-admin.php
@@ -52,6 +52,8 @@ class Algolia_Admin {
 			}
 		}
 
+		new Algolia_Admin_Template_Notices();
+
 		new Algolia_Admin_Page_Settings( $plugin );
 
 		add_action( 'admin_notices', array( $this, 'display_unmet_requirements_notices' ) );

--- a/includes/utilities/class-algolia-template-utils.php
+++ b/includes/utilities/class-algolia-template-utils.php
@@ -32,6 +32,18 @@ class Algolia_Template_Utils {
 	const THEME_TEMPLATES_DIR = 'algolia';
 
 	/**
+	 * The template file names.
+	 *
+	 * @since 1.8.0-dev
+	 *
+	 * @var string[]
+	 */
+	const TEMPLATE_FILE_NAMES = [
+		'autocomplete.php',
+		'instantsearch.php',
+	];
+
+	/**
 	 * Get the plugin templates directory with trailing slash.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
@@ -232,5 +244,85 @@ class Algolia_Template_Utils {
 		}
 
 		return _cleanup_header_comment( $matches[1] );
+	}
+
+	/**
+	 * Get the Alglia Template File Names.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @return array
+	 */
+	public static function get_template_file_names(): array {
+		return (array) self::TEMPLATE_FILE_NAMES;
+	}
+
+	/**
+	 * Get unfiltered array of plugin's core template paths.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @return array An array of the plugin's core template paths.
+	 */
+	public static function get_core_template_paths(): array {
+		$plugin_template_paths = [];
+		$template_filenames    = self::get_template_file_names();
+		foreach ( $template_filenames as $file ) {
+			$plugin_template_paths[ $file ] = self::get_default_template( $file );
+		}
+
+		return (array) $plugin_template_paths;
+	}
+
+	/**
+	 * Get array of located template paths.
+	 *
+	 * There are numerous filters related to changing template locations,
+	 * which makes it a little more difficult than it should be
+	 * to find where a "customized" template actually exists.
+	 * For that reason, we will call this "located template paths."
+	 * They aren't necessarily customized template paths from the theme,
+	 * they might be the same as the plugin's core templates.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @return array
+	 */
+	public static function get_located_template_paths(): array {
+		$located_template_paths = [];
+		$template_filenames     = self::get_template_file_names();
+		foreach ( $template_filenames as $file ) {
+			$located_template_paths[ $file ] = self::locate_template( $file );
+		}
+
+		return (array) $located_template_paths;
+	}
+
+	/**
+	 * Get array of custom template paths.
+	 *
+	 * Diffs the plugin's core template paths against the located template paths.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @return array Array of custom template paths,
+	 *               else empty array if no custom templates found.
+	 */
+	public static function get_custom_template_paths(): array {
+
+		$customized_template_paths = array_diff(
+			self::get_located_template_paths(),
+			self::get_core_template_paths()
+		);
+
+		if ( empty( $customized_template_paths ) ) {
+			return [];
+		}
+
+		return (array) $customized_template_paths;
 	}
 }

--- a/includes/utilities/class-algolia-template-utils.php
+++ b/includes/utilities/class-algolia-template-utils.php
@@ -154,6 +154,10 @@ class Algolia_Template_Utils {
 	/**
 	 * Locate a template.
 	 *
+	 * There are numerous filters related to changing template locations,
+	 * which makes it a little more difficult than it should be
+	 * to find where a "customized" template actually exists.
+	 *
 	 * @author  WebDevStudios <contact@webdevstudios.com>
 	 * @since   1.8.0-dev
 	 *
@@ -210,7 +214,9 @@ class Algolia_Template_Utils {
 	 *
 	 * @param string $template Full path to the template file.
 	 *
-	 * @return string
+	 * @return null|string Template version number string if it exists,
+	 *                     empty string if no version number exists,
+	 *                     else null if template file is not found or can't be read.
 	 */
 	public static function get_template_version( $template ): ?string {
 

--- a/includes/utilities/class-algolia-template-utils.php
+++ b/includes/utilities/class-algolia-template-utils.php
@@ -212,7 +212,7 @@ class Algolia_Template_Utils {
 	 *
 	 * @return string
 	 */
-	public static function get_version( $template ): ?string {
+	public static function get_template_version( $template ): ?string {
 
 		// Null, if template file does not exist or cannot be read.
 		if ( ! is_file( $template ) || ! is_readable( $template ) ) {

--- a/includes/utilities/class-algolia-version-utils.php
+++ b/includes/utilities/class-algolia-version-utils.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Algolia_Version_Utils class file.
+ *
+ * @author  WebDevStudios <contact@webdevstudios.com>
+ * @since   1.8.0-dev
+ *
+ * @package WebDevStudios\WPSWA
+ */
+
+/**
+ * Class Algolia_Version_Utils
+ *
+ * @since 1.8.0-dev
+ */
+class Algolia_Version_Utils {
+
+	/**
+	 * Semantic versioning regular expression pattern.
+	 *
+	 * @link https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+	 * @link https://regex101.com/r/Ly7O1x/3/
+	 *
+	 * @since   1.8.0-dev
+	 *
+	 * @var string
+	 */
+	const SEMVER_PATTERN = '%^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$%';
+
+	/**
+	 * Parse version string into array of semver components.
+	 *
+	 * Supports MAJOR.MINOR.PATCH-prerelease+buildmetadata.
+	 * Given a valid semantic version string, such as '1.8.0-dev+build.1',
+	 * will return an array of matches that follow Semantic Versioning 2.0.0.
+	 * Example return...
+	 *     $matches = [
+	 *         0               => '1.8.0-dev+build.1',
+	 *         'major'         => '1',
+	 *         1               => '1',
+	 *         'minor'         => '8',
+	 *         2               => '8',
+	 *         'patch'         => '0',
+	 *         3               => '0',
+	 *         'prerelease'    => 'dev',
+	 *         4               => 'dev',
+	 *         'buildmetadata' => 'build.1',
+	 *         5               => 'build.1',
+	 *     ];
+	 *
+	 * @link https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @param string $version Version number string.
+	 *
+	 * @return array
+	 */
+	public static function parse_semver_version_string( string $version ): array {
+		$matches = [];
+		preg_match(
+			self::SEMVER_PATTERN,
+			$version,
+			$matches
+		);
+
+		return $matches;
+	}
+
+	/**
+	 * Get the MAJOR version number from version string.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @param string $version Version number string.
+	 *
+	 * @return int|null
+	 */
+	public static function get_major_version( string $version ): ?int {
+		$matches = self::parse_semver_version_string( $version );
+		if ( empty( $matches['major'] ) ) {
+			return null;
+		}
+
+		return (int) $matches['major'];
+	}
+
+	/**
+	 * Get the MINOR version number from version string.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @param string $version Version number string.
+	 *
+	 * @return int|null
+	 */
+	public static function get_minor_version( string $version ): ?int {
+		$matches = self::parse_semver_version_string( $version );
+		if ( empty( $matches['minor'] ) ) {
+			return null;
+		}
+
+		return (int) $matches['minor'];
+	}
+
+	/**
+	 * Get the PATCH version number from version string.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @param string $version Version number string.
+	 *
+	 * @return int|null
+	 */
+	public static function get_patch_version( string $version ): ?int {
+		$matches = self::parse_semver_version_string( $version );
+		if ( empty( $matches['patch'] ) ) {
+			return null;
+		}
+
+		return (int) $matches['patch'];
+	}
+}


### PR DESCRIPTION
Add utility methods to get the core templates, located templates, and customized templates
Add version utility class with methods to parse version strings and return MAJOR, MINOR, PATCH version numbers
Add class to display template version notices
Rename Algolia_Template_Utils::get_version method to Algolia_Template_Utils::get_template_version
Require version utils and admin notices files
Expand get_template_version docblock
Add Algolia_Admin_Template_Notices to Algolia_Admin
Update classmap to require the correct filename
Display the admin notice for any version mismatch, not just MAJOR

If a customized template is present in the theme, and its version string does not match that of the corresponding template in the plugin, or the customized template version is unknown, display an admin error notice.

UPDATED to show the admin notice for any version discrepancy, not just MAJOR.

![Screen Shot 2021-04-16 at 3 25 36 PM](https://user-images.githubusercontent.com/5407441/115081034-40efbb00-9ec9-11eb-993a-72e5a7d8d6eb.png)
