### PR TITLE
Release 1.8.0

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Tags: Search, Algolia, Autocomplete, instant-search, relevant search, search hig
 Requires at least: 5.0
 Tested up to: 5.7
 Requires PHP: 7.2
-Stable tag: 1.7.0
+Stable tag: 1.8.0
 License: GNU General Public License v2.0, MIT License
 
 Improve search on your site. Autocomplete is included, along with full control over look, feel and relevance.
@@ -106,7 +106,7 @@ WebDevStudios provides end-to-end WordPress opportunities from strategy and plan
 
 Follow along with the changelog on [Github](https://github.com/WebDevStudios/wp-search-with-algolia/releases).
 
-= 1.8.0-dev =
+= 1.8.0 =
 * Focus on template versioning and update messaging
 * Add Algolia_Template_Utils class
 * Deprecate Algolia_Template_Loader::locate_template method

--- a/README.txt
+++ b/README.txt
@@ -25,7 +25,7 @@ This plugin requires API keys from [Algolia](https://www.algolia.com/). API keys
 = Links =
 * [WebDevStudios](https://webdevstudios.com)
 * [Algolia](https://algolia.com)
-* [Documentation](https://community.algolia.com/wordpress/configuration.html)
+* [Documentation](https://github.com/WebDevStudios/wp-search-with-algolia/wiki)
 * [Support](https://github.com/WebDevStudios/wp-search-with-algolia/issues)
 
 *This plugin is a derivative work of the code from the [Search by Algolia – Instant & Relevant results](https://wordpress.org/plugins/search-by-algolia-instant-relevant-results/) plugin for WordPress, which is licensed under the GPLv2.*
@@ -40,7 +40,7 @@ From your WordPress dashboard:
 2. **Search** for "WP Search with Algolia"
 3. **Activate** WP Search with Algolia from your Plugins page
 4. **Click** on the new menu item "Algolia Search" and enter your API keys
-5. **Read** the step by step [configuration guide](https://community.algolia.com/wordpress/configuration.html)
+5. **Read** the step by step [configuration guide](https://github.com/WebDevStudios/wp-search-with-algolia/wiki/Getting-Started)
 
 == Frequently Asked Questions ==
 
@@ -70,17 +70,17 @@ Yes. Because Algolia no longer supports their plugin, you will no longer receive
 * OpenSSL greater than 1.0.1
 * Some payment gateways require fsockopen support (for IPN access)
 
-Visit the [Search by Algolia server requirements documentation](https://community.algolia.com/wordpress/installation.html) for a detailed list of server requirements.
+Visit the [Search by Algolia server requirements documentation](https://github.com/WebDevStudios/wp-search-with-algolia/wiki/WP-Search-with-Algolia-plugin-Installation) for a detailed list of server requirements.
 
 = Where can I find Algolia documentation and user guides? =
 
-- For help setting up and configuring Search by Algolia please refer to the [user guide](https://community.algolia.com/wordpress/installation.html).
-- For extending or theming the Autocomplete dropdown, see the [Autocomplete Customization guide](https://community.algolia.com/wordpress/customize-autocomplete.html).
-- For extending or theming the Instant Search results page, see the [Search Page Customization guide](https://community.algolia.com/wordpress/customize-search-page.html).
+- For help setting up and configuring WP Search with Algolia please refer to the [user guide](https://github.com/WebDevStudios/wp-search-with-algolia/wiki/WP-Search-with-Algolia-plugin-Installation).
+- For extending or theming the Autocomplete dropdown, see the [Autocomplete Customization guide](https://github.com/WebDevStudios/wp-search-with-algolia/wiki/Customize-the-Autocomplete-dropdown).
+- For extending or theming the Instant Search results page, see the [Search Page Customization guide](https://github.com/WebDevStudios/wp-search-with-algolia/wiki/Customize-your-search-page).
 
 = Will it work with my theme? =
 
-Yes. This plugin will work with any theme, but the Instant Search results page may require some styling to make it match nicely. See the [Search Page Customization](https://community.algolia.com/wordpress/customize-search-page.html).
+Yes. This plugin will work with any theme, but the Instant Search results page may require some styling to make it match nicely. See the [Search Page Customization](https://github.com/WebDevStudios/wp-search-with-algolia/wiki/Customize-your-search-page).
 
 = Where can I report bugs, request features, or contribute to the project? =
 

--- a/README.txt
+++ b/README.txt
@@ -110,10 +110,14 @@ WebDevStudios provides end-to-end WordPress opportunities from strategy and plan
 Follow along with the changelog on [Github](https://github.com/WebDevStudios/wp-search-with-algolia/releases).
 
 = 1.8.0-dev =
+* Focus on template versioning and update messaging
 * Add Algolia_Template_Utils class
-* Deprecate Algolia_Template_Loader::locate_template
+* Deprecate Algolia_Template_Loader::locate_template method
 * Deprecate Algolia_Plugin::get_templates_path method
 * Deprecate algolia_templates_path filter
+* Add Algolia_Update_Messages class
+* Add Algolia_Admin_Template_Notices class
+* Add Algolia_Version_Utils class
 
 = 1.7.0 =
 * Remove 'screen' media attribute from enqueued CSS

--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,3 @@
-
 === WP Search with Algolia ===
 Contributors: WebDevStudios, williamsba1, gregrickaby, tw2113, richaber, mrasharirfan
 Tags: Search, Algolia, Autocomplete, instant-search, relevant search, search highlight, faceted search, find-as-you-type search, suggest, search by category, ajax search, better search, custom search

--- a/README.txt
+++ b/README.txt
@@ -109,6 +109,12 @@ WebDevStudios provides end-to-end WordPress opportunities from strategy and plan
 
 Follow along with the changelog on [Github](https://github.com/WebDevStudios/wp-search-with-algolia/releases).
 
+= 1.8.0-dev =
+* Add Algolia_Template_Utils class
+* Deprecate Algolia_Template_Loader::locate_template
+* Deprecate Algolia_Plugin::get_templates_path method
+* Deprecate algolia_templates_path filter
+
 = 1.7.0 =
 * Remove 'screen' media attribute from enqueued CSS
 * Update Algolia PHP Search Client to version 2.7.3.

--- a/README.txt
+++ b/README.txt
@@ -70,7 +70,7 @@ Yes. Because Algolia no longer supports their plugin, you will no longer receive
 * OpenSSL greater than 1.0.1
 * Some payment gateways require fsockopen support (for IPN access)
 
-Visit the [Search by Algolia server requirements documentation](https://github.com/WebDevStudios/wp-search-with-algolia/wiki/WP-Search-with-Algolia-plugin-Installation) for a detailed list of server requirements.
+Visit the [WP Search with Algolia server requirements documentation](https://github.com/WebDevStudios/wp-search-with-algolia/wiki/WP-Search-with-Algolia-plugin-Installation) for a detailed list of server requirements.
 
 = Where can I find WP Search with Algolia documentation and user guides? =
 

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@
 Contributors: WebDevStudios, williamsba1, gregrickaby, tw2113, richaber, mrasharirfan
 Tags: Search, Algolia, Autocomplete, instant-search, relevant search, search highlight, faceted search, find-as-you-type search, suggest, search by category, ajax search, better search, custom search
 Requires at least: 5.0
-Tested up to: 5.5
+Tested up to: 5.7
 Requires PHP: 7.2
 Stable tag: 1.7.0
 License: GNU General Public License v2.0, MIT License

--- a/README.txt
+++ b/README.txt
@@ -80,7 +80,7 @@ Visit the [WP Search with Algolia server requirements documentation](https://git
 
 = Will it work with my theme? =
 
-Yes. This plugin will work with any theme, but the Instant Search results page may require some styling to make it match nicely. See the [Search Page Customization](https://github.com/WebDevStudios/wp-search-with-algolia/wiki/Customize-your-search-page).
+Yes. This plugin should work with most themes that do not override the default WordPress search behavior. Instant Search results page may require some styling to make it match nicely. See the [Search Page Customization](https://github.com/WebDevStudios/wp-search-with-algolia/wiki/Customize-your-search-page).
 
 = Where can I report bugs, request features, or contribute to the project? =
 

--- a/README.txt
+++ b/README.txt
@@ -90,8 +90,6 @@ All development is handled on [GitHub](https://github.com/WebDevStudios/wp-searc
 
 Algolia offers its Search as a Service provider on a incremental payment program, including a free Community Plan which includes 10,000 records & 50,000 operations per month. Beyond that, [plans](https://www.algolia.com/pricing/) start at $29/month.
 
-*Note: there isn't a direct correlation between the number of posts in WordPress and the number of records in Algolia. Also note that we only offer support starting from the PRO plan.On average, you can expect to have about 10 times more records than you have posts, though this is not a golden rule and you could end up with more records.*
-
 = About WebDevStudios =
 
 WebDevStudios provides end-to-end WordPress opportunities from strategy and planning to website design and development, as well as full data migration, extensive API integrations, scalability, performance and long-term guidance and maintenance. We have service options and solutions for start-ups, small to mid-size businesses, enterprise organizations and marketing agencies.

--- a/README.txt
+++ b/README.txt
@@ -72,7 +72,7 @@ Yes. Because Algolia no longer supports their plugin, you will no longer receive
 
 Visit the [Search by Algolia server requirements documentation](https://github.com/WebDevStudios/wp-search-with-algolia/wiki/WP-Search-with-Algolia-plugin-Installation) for a detailed list of server requirements.
 
-= Where can I find Algolia documentation and user guides? =
+= Where can I find WP Search with Algolia documentation and user guides? =
 
 - For help setting up and configuring WP Search with Algolia please refer to the [user guide](https://github.com/WebDevStudios/wp-search-with-algolia/wiki/WP-Search-with-Algolia-plugin-Installation).
 - For extending or theming the Autocomplete dropdown, see the [Autocomplete Customization guide](https://github.com/WebDevStudios/wp-search-with-algolia/wiki/Customize-the-Autocomplete-dropdown).

--- a/algolia.php
+++ b/algolia.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WP Search with Algolia
  * Plugin URI:        https://github.com/WebDevStudios/wp-search-with-algolia
  * Description:       Integrate the powerful Algolia search service with WordPress
- * Version:           1.7.0
+ * Version:           1.8.0-dev
  * Requires at least: 5.0
  * Requires PHP:      7.2
  * Author:            WebDevStudios
@@ -26,7 +26,7 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 // The Algolia Search plugin version.
-define( 'ALGOLIA_VERSION', '1.7.0' );
+define( 'ALGOLIA_VERSION', '1.8.0-dev' );
 
 // The minmum required PHP version.
 define( 'ALGOLIA_MIN_PHP_VERSION', '7.2' );

--- a/algolia.php
+++ b/algolia.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WP Search with Algolia
  * Plugin URI:        https://github.com/WebDevStudios/wp-search-with-algolia
  * Description:       Integrate the powerful Algolia search service with WordPress
- * Version:           1.8.0-dev
+ * Version:           1.8.0
  * Requires at least: 5.0
  * Requires PHP:      7.2
  * Author:            WebDevStudios
@@ -26,7 +26,7 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 // The Algolia Search plugin version.
-define( 'ALGOLIA_VERSION', '1.8.0-dev' );
+define( 'ALGOLIA_VERSION', '1.8.0' );
 
 // The minmum required PHP version.
 define( 'ALGOLIA_MIN_PHP_VERSION', '7.2' );

--- a/classmap.php
+++ b/classmap.php
@@ -44,6 +44,8 @@ require_once ALGOLIA_PATH . 'includes/watchers/class-algolia-post-changes-watche
 require_once ALGOLIA_PATH . 'includes/watchers/class-algolia-term-changes-watcher.php';
 require_once ALGOLIA_PATH . 'includes/watchers/class-algolia-user-changes-watcher.php';
 
+require_once ALGOLIA_PATH . 'includes/utilities/class-algolia-template-utils.php';
+
 if ( is_admin() ) {
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin.php';
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin-page-autocomplete.php';

--- a/classmap.php
+++ b/classmap.php
@@ -46,6 +46,7 @@ require_once ALGOLIA_PATH . 'includes/watchers/class-algolia-user-changes-watche
 
 require_once ALGOLIA_PATH . 'includes/utilities/class-algolia-template-utils.php';
 require_once ALGOLIA_PATH . 'includes/utilities/class-algolia-version-utils.php';
+require_once ALGOLIA_PATH . 'includes/utilities/class-algolia-update-messages.php';
 
 if ( is_admin() ) {
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin.php';

--- a/classmap.php
+++ b/classmap.php
@@ -45,10 +45,12 @@ require_once ALGOLIA_PATH . 'includes/watchers/class-algolia-term-changes-watche
 require_once ALGOLIA_PATH . 'includes/watchers/class-algolia-user-changes-watcher.php';
 
 require_once ALGOLIA_PATH . 'includes/utilities/class-algolia-template-utils.php';
+require_once ALGOLIA_PATH . 'includes/utilities/class-algolia-version-utils.php';
 
 if ( is_admin() ) {
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin.php';
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin-page-autocomplete.php';
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin-page-native-search.php';
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin-page-settings.php';
+	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin-template-notices.php';
 }

--- a/includes/admin/class-algolia-admin-template-notices.php
+++ b/includes/admin/class-algolia-admin-template-notices.php
@@ -3,7 +3,7 @@
  * Algolia_Admin_Template_Notices class file.
  *
  * @author  WebDevStudios <contact@webdevstudios.com>
- * @since   1.8.0-dev
+ * @since   1.8.0
  *
  * @package WebDevStudios\WPSWA
  */
@@ -11,7 +11,7 @@
 /**
  * Class Algolia_Admin_Template_Notices
  *
- * @since 1.8.0-dev
+ * @since 1.8.0
  */
 class Algolia_Admin_Template_Notices {
 
@@ -19,7 +19,7 @@ class Algolia_Admin_Template_Notices {
 	 * Algolia_Admin_Template_Notices constructor.
 	 *
 	 * @author  WebDevStudios <contact@webdevstudios.com>
-	 * @since   1.8.0-dev
+	 * @since   1.8.0
 	 */
 	public function __construct() {
 		add_action( 'admin_notices', [ $this, 'template_version_notices' ] );
@@ -29,7 +29,7 @@ class Algolia_Admin_Template_Notices {
 	 * Display template version discrepencany notices.
 	 *
 	 * @author  WebDevStudios <contact@webdevstudios.com>
-	 * @since   1.8.0-dev
+	 * @since   1.8.0
 	 *
 	 * @return void
 	 */

--- a/includes/admin/class-algolia-admin-template-notices.php
+++ b/includes/admin/class-algolia-admin-template-notices.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Algolia_Admin_Template_Notices class file.
+ *
+ * @author  WebDevStudios <contact@webdevstudios.com>
+ * @since   1.8.0-dev
+ *
+ * @package WebDevStudios\WPSWA
+ */
+
+/**
+ * Class Algolia_Admin_Template_Notices
+ *
+ * @since 1.8.0-dev
+ */
+class Algolia_Admin_Template_Notices {
+
+	/**
+	 * Algolia_Admin_Template_Notices constructor.
+	 *
+	 * @author  WebDevStudios <contact@webdevstudios.com>
+	 * @since   1.8.0-dev
+	 */
+	public function __construct() {
+		add_action( 'admin_notices', [ $this, 'template_version_notices' ] );
+	}
+
+	/**
+	 * Display template version discrepencany notices.
+	 *
+	 * @author  WebDevStudios <contact@webdevstudios.com>
+	 * @since   1.8.0-dev
+	 *
+	 * @return void
+	 */
+	public function template_version_notices() {
+
+		$core_template_paths = Algolia_Template_Utils::get_core_template_paths();
+
+		$custom_template_paths = Algolia_Template_Utils::get_custom_template_paths();
+
+		if ( empty( $custom_template_paths ) ) {
+			return;
+		}
+
+		$core_template_versions = [];
+
+		$custom_template_versions = [];
+
+		foreach ( $custom_template_paths as $filename => $file_path ) {
+			$core_template_versions[ $filename ]   = Algolia_Template_Utils::get_template_version(
+				$core_template_paths[ $filename ]
+			);
+			$custom_template_versions[ $filename ] = Algolia_Template_Utils::get_template_version(
+				$file_path
+			);
+		}
+
+		foreach ( $custom_template_versions as $filename => $file_version ) {
+			// Error if versions do not match, or custom template version unknown.
+			if ( version_compare( $file_version, $core_template_versions[ $filename ], '!=' ) ) {
+				$error_notices[] = sprintf(
+					/* translators: placeholder 1 is template filename, placeholder 2 is custom template version, placeholder 3 is core template version. */
+					esc_html__(
+						'Your custom WP Search With Algolia template file, %1$s, version %2$s is out of date. The core version is %3$s',
+						'wp-search-with-algolia'
+					),
+					$filename,
+					! empty( $file_version ) ? $file_version : __( 'unknown', 'wp-search-with-algolia' ),
+					$core_template_versions[ $filename ]
+				);
+			}
+		}
+
+		if ( empty( $error_notices ) ) {
+			return;
+		}
+
+		foreach ( $error_notices as $error_notice ) {
+			echo '<div class="notice notice-error"><p>' . esc_html( $error_notice ) . '</p></div>';
+		}
+	}
+}

--- a/includes/admin/class-algolia-admin.php
+++ b/includes/admin/class-algolia-admin.php
@@ -52,6 +52,8 @@ class Algolia_Admin {
 			}
 		}
 
+		new Algolia_Admin_Template_Notices();
+
 		new Algolia_Admin_Page_Settings( $plugin );
 
 		add_action( 'admin_notices', array( $this, 'display_unmet_requirements_notices' ) );

--- a/includes/class-algolia-plugin.php
+++ b/includes/class-algolia-plugin.php
@@ -88,6 +88,16 @@ class Algolia_Plugin {
 	private $scripts;
 
 	/**
+	 * Instance of Algolia_Update_Messages.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @var Algolia_Update_Messages
+	 */
+	private $update_messages;
+
+	/**
 	 * Instance of Algolia_Template_Loader.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
@@ -129,11 +139,13 @@ class Algolia_Plugin {
 	 * @since  1.0.0
 	 */
 	public function __construct() {
-		$this->settings      = new Algolia_Settings();
-		$this->api           = new Algolia_API( $this->settings );
-		$this->compatibility = new Algolia_Compatibility();
-		$this->styles        = new Algolia_Styles();
-		$this->scripts       = new Algolia_Scripts();
+		$this->settings        = new Algolia_Settings();
+		$this->api             = new Algolia_API( $this->settings );
+		$this->compatibility   = new Algolia_Compatibility();
+		$this->styles          = new Algolia_Styles();
+		$this->scripts         = new Algolia_Scripts();
+		$this->update_messages = new Algolia_Update_Messages();
+
 		add_action( 'init', array( $this, 'load' ), 20 );
 	}
 

--- a/includes/class-algolia-plugin.php
+++ b/includes/class-algolia-plugin.php
@@ -91,7 +91,7 @@ class Algolia_Plugin {
 	 * Instance of Algolia_Update_Messages.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  1.8.0-dev
+	 * @since  1.8.0
 	 *
 	 * @var Algolia_Update_Messages
 	 */
@@ -411,7 +411,7 @@ class Algolia_Plugin {
 	 *
 	 * @author     WebDevStudios <contact@webdevstudios.com>
 	 * @since      1.0.0
-	 * @deprecated 1.8.0-dev Use Algolia_Template_Utils::get_filtered_theme_templates_dirname()
+	 * @deprecated 1.8.0 Use Algolia_Template_Utils::get_filtered_theme_templates_dirname()
 	 * @see        Algolia_Template_Utils::get_filtered_theme_templates_dirname()
 	 *
 	 * @return string
@@ -419,7 +419,7 @@ class Algolia_Plugin {
 	public function get_templates_path() {
 		_deprecated_function(
 			__METHOD__,
-			'1.8.0-dev',
+			'1.8.0',
 			'Algolia_Template_Utils::get_filtered_theme_templates_dirname()'
 		);
 		return (string) Algolia_Template_Utils::get_filtered_theme_templates_dirname();

--- a/includes/class-algolia-plugin.php
+++ b/includes/class-algolia-plugin.php
@@ -394,13 +394,23 @@ class Algolia_Plugin {
 	/**
 	 * Get the templates path.
 	 *
-	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  1.0.0
+	 * Somewhat misleading method name.
+	 * Actually returns a path segment (directory name) with trailing slash.
+	 *
+	 * @author     WebDevStudios <contact@webdevstudios.com>
+	 * @since      1.0.0
+	 * @deprecated 1.8.0-dev Use Algolia_Template_Utils::get_filtered_theme_templates_dirname()
+	 * @see        Algolia_Template_Utils::get_filtered_theme_templates_dirname()
 	 *
 	 * @return string
 	 */
 	public function get_templates_path() {
-		return (string) apply_filters( 'algolia_templates_path', 'algolia/' );
+		_deprecated_function(
+			__METHOD__,
+			'1.8.0-dev',
+			'Algolia_Template_Utils::get_filtered_theme_templates_dirname()'
+		);
+		return (string) Algolia_Template_Utils::get_filtered_theme_templates_dirname();
 	}
 
 	/**

--- a/includes/class-algolia-template-loader.php
+++ b/includes/class-algolia-template-loader.php
@@ -156,8 +156,8 @@ class Algolia_Template_Loader {
 	 *
 	 * Handles template usage so that we can use our own templates instead of the themes.
 	 *
-	 * Templates are in the 'templates' folder. algolia looks for theme.
-	 * overrides in /your-theme/algolia/ by default.
+	 * Plugin templates are located in the 'templates' directory.
+	 * Customized templates are in the theme's 'algolia' directory.
 	 *
 	 * @author  WebDevStudios <contact@webdevstudios.com>
 	 * @since   1.0.0
@@ -198,7 +198,7 @@ class Algolia_Template_Loader {
 			}
 		);
 
-		return $this->locate_template( 'instantsearch.php' );
+		return Algolia_Template_Utils::locate_template( 'instantsearch.php' );
 	}
 
 	/**
@@ -208,35 +208,27 @@ class Algolia_Template_Loader {
 	 * @since   1.0.0
 	 */
 	public function load_autocomplete_template() {
-		require $this->locate_template( 'autocomplete.php' );
+		require Algolia_Template_Utils::locate_template( 'autocomplete.php' );
 	}
 
 	/**
 	 * Locate a template.
 	 *
-	 * @author  WebDevStudios <contact@webdevstudios.com>
-	 * @since   1.0.0
+	 * @author     WebDevStudios <contact@webdevstudios.com>
+	 * @since      1.0.0
+	 * @deprecated 1.8.0-dev Use Algolia_Template_Utils::locate_template()
+	 * @see        Algolia_Template_Utils::locate_template()
 	 *
 	 * @param string $file The template file.
 	 *
 	 * @return string
 	 */
 	private function locate_template( $file ) {
-		$locations[] = $file;
-
-		$templates_path = $this->plugin->get_templates_path();
-		if ( 'algolia/' !== $templates_path ) {
-			$locations[] = 'algolia/' . $file;
-		}
-
-		$locations[] = $templates_path . $file;
-
-		$locations = (array) apply_filters( 'algolia_template_locations', $locations, $file );
-
-		$template = locate_template( array_unique( $locations ) );
-
-		$default_template = (string) apply_filters( 'algolia_default_template', $this->plugin->get_path() . '/templates/' . $file, $file );
-
-		return $template ? $template : $default_template;
+		_deprecated_function(
+			__METHOD__,
+			'1.8.0-dev',
+			'Algolia_Template_Utils::locate_template()'
+		);
+		return Algolia_Template_Utils::locate_template( $file );
 	}
 }

--- a/includes/class-algolia-template-loader.php
+++ b/includes/class-algolia-template-loader.php
@@ -216,7 +216,7 @@ class Algolia_Template_Loader {
 	 *
 	 * @author     WebDevStudios <contact@webdevstudios.com>
 	 * @since      1.0.0
-	 * @deprecated 1.8.0-dev Use Algolia_Template_Utils::locate_template()
+	 * @deprecated 1.8.0 Use Algolia_Template_Utils::locate_template()
 	 * @see        Algolia_Template_Utils::locate_template()
 	 *
 	 * @param string $file The template file.
@@ -226,7 +226,7 @@ class Algolia_Template_Loader {
 	private function locate_template( $file ) {
 		_deprecated_function(
 			__METHOD__,
-			'1.8.0-dev',
+			'1.8.0',
 			'Algolia_Template_Utils::locate_template()'
 		);
 		return Algolia_Template_Utils::locate_template( $file );

--- a/includes/utilities/class-algolia-template-utils.php
+++ b/includes/utilities/class-algolia-template-utils.php
@@ -32,6 +32,18 @@ class Algolia_Template_Utils {
 	const THEME_TEMPLATES_DIR = 'algolia';
 
 	/**
+	 * The template file names.
+	 *
+	 * @since 1.8.0-dev
+	 *
+	 * @var string[]
+	 */
+	const TEMPLATE_FILE_NAMES = [
+		'autocomplete.php',
+		'instantsearch.php',
+	];
+
+	/**
 	 * Get the plugin templates directory with trailing slash.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
@@ -142,6 +154,10 @@ class Algolia_Template_Utils {
 	/**
 	 * Locate a template.
 	 *
+	 * There are numerous filters related to changing template locations,
+	 * which makes it a little more difficult than it should be
+	 * to find where a "customized" template actually exists.
+	 *
 	 * @author  WebDevStudios <contact@webdevstudios.com>
 	 * @since   1.8.0-dev
 	 *
@@ -198,9 +214,11 @@ class Algolia_Template_Utils {
 	 *
 	 * @param string $template Full path to the template file.
 	 *
-	 * @return string
+	 * @return null|string Template version number string if it exists,
+	 *                     empty string if no version number exists,
+	 *                     else null if template file is not found or can't be read.
 	 */
-	public static function get_version( $template ): ?string {
+	public static function get_template_version( $template ): ?string {
 
 		// Null, if template file does not exist or cannot be read.
 		if ( ! is_file( $template ) || ! is_readable( $template ) ) {
@@ -232,5 +250,85 @@ class Algolia_Template_Utils {
 		}
 
 		return _cleanup_header_comment( $matches[1] );
+	}
+
+	/**
+	 * Get the Alglia Template File Names.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @return array
+	 */
+	public static function get_template_file_names(): array {
+		return (array) self::TEMPLATE_FILE_NAMES;
+	}
+
+	/**
+	 * Get unfiltered array of plugin's core template paths.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @return array An array of the plugin's core template paths.
+	 */
+	public static function get_core_template_paths(): array {
+		$plugin_template_paths = [];
+		$template_filenames    = self::get_template_file_names();
+		foreach ( $template_filenames as $file ) {
+			$plugin_template_paths[ $file ] = self::get_default_template( $file );
+		}
+
+		return (array) $plugin_template_paths;
+	}
+
+	/**
+	 * Get array of located template paths.
+	 *
+	 * There are numerous filters related to changing template locations,
+	 * which makes it a little more difficult than it should be
+	 * to find where a "customized" template actually exists.
+	 * For that reason, we will call this "located template paths."
+	 * They aren't necessarily customized template paths from the theme,
+	 * they might be the same as the plugin's core templates.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @return array
+	 */
+	public static function get_located_template_paths(): array {
+		$located_template_paths = [];
+		$template_filenames     = self::get_template_file_names();
+		foreach ( $template_filenames as $file ) {
+			$located_template_paths[ $file ] = self::locate_template( $file );
+		}
+
+		return (array) $located_template_paths;
+	}
+
+	/**
+	 * Get array of custom template paths.
+	 *
+	 * Diffs the plugin's core template paths against the located template paths.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @return array Array of custom template paths,
+	 *               else empty array if no custom templates found.
+	 */
+	public static function get_custom_template_paths(): array {
+
+		$customized_template_paths = array_diff(
+			self::get_located_template_paths(),
+			self::get_core_template_paths()
+		);
+
+		if ( empty( $customized_template_paths ) ) {
+			return [];
+		}
+
+		return (array) $customized_template_paths;
 	}
 }

--- a/includes/utilities/class-algolia-template-utils.php
+++ b/includes/utilities/class-algolia-template-utils.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * Algolia_Template_Utils class file.
+ *
+ * @since   1.8.0-dev
+ * @package WebDevStudios\WPSWA
+ */
+
+/**
+ * Class Algolia_Template_Utils
+ *
+ * @since 1.8.0-dev
+ */
+class Algolia_Template_Utils {
+
+	/**
+	 * The plugin template directory name.
+	 *
+	 * @since 1.8.0-dev
+	 *
+	 * @var string
+	 */
+	const PLUGIN_TEMPLATES_DIR = 'templates';
+
+	/**
+	 * The theme template directory name.
+	 *
+	 * @since 1.8.0-dev
+	 *
+	 * @var string
+	 */
+	const THEME_TEMPLATES_DIR = 'algolia';
+
+	/**
+	 * Get the plugin templates directory with trailing slash.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @return string The plugin templates directory name with trailing slash.
+	 */
+	public static function get_plugin_templates_dirname() {
+		return (string) self::PLUGIN_TEMPLATES_DIR . '/';
+	}
+
+	/**
+	 * Get the "unfiltered" theme templates directory with trailing slash.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @return string The theme templates directory name with trailing slash.
+	 */
+	public static function get_theme_templates_dirname() {
+		return (string) self::THEME_TEMPLATES_DIR . '/';
+	}
+
+	/**
+	 * Get the "filtered" theme templates directory name with trailing slash.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @return string The theme templates directory name with trailing slash.
+	 */
+	public static function get_filtered_theme_templates_dirname() {
+
+		$path = self::get_theme_templates_dirname();
+
+		/**
+		 * Allow developers to override the theme templates dirname.
+		 *
+		 * @since      1.0.0
+		 * @deprecated 1.8.0-dev Use {@see 'algolia_theme_templates_dirname'} instead.
+		 *
+		 * @param string $path The theme templates directory name with trailing slash.
+		 *                     Defaults to 'algolia/'.
+		 */
+		$path = (string) apply_filters_deprecated(
+			'algolia_templates_path',
+			[ $path ],
+			'1.8.0-dev',
+			'algolia_theme_templates_dirname'
+		);
+
+		/**
+		 * Allow developers to override the theme templates dirname.
+		 *
+		 * @since  1.8.0-dev
+		 *
+		 * @param string $path The theme templates directory name with trailing slash.
+		 *                     Defaults to 'algolia/'.
+		 */
+		return (string) apply_filters(
+			'algolia_theme_templates_dirname',
+			$path
+		);
+	}
+
+	/**
+	 * Get the "unfiltered" full path to the default template file in the plugin.
+	 *
+	 * @author  WebDevStudios <contact@webdevstudios.com>
+	 * @since   1.8.0-dev
+	 *
+	 * @param string $file The template filename.
+	 *
+	 * @return string Full path to the template file.
+	 */
+	public static function get_default_template( $file ) {
+		return (string) ALGOLIA_PATH . self::get_plugin_templates_dirname() . $file;
+	}
+
+	/**
+	 * Get the "filtered" full path to the default template file in the plugin.
+	 *
+	 * @author  WebDevStudios <contact@webdevstudios.com>
+	 * @since   1.8.0-dev
+	 *
+	 * @param string $file The template filename.
+	 *
+	 * @return string Full path to the template file.
+	 */
+	public static function get_filtered_default_template( $file ) {
+		/**
+		 * Allow developers to override the default template.
+		 *
+		 * @todo Should this even be allowed?
+		 *
+		 * @since  1.0.0
+		 *
+		 * @param string $template Full path to the default template file.
+		 * @param string $file     The default template file.
+		 */
+		return (string) apply_filters(
+			'algolia_default_template',
+			self::get_default_template( $file ),
+			$file
+		);
+	}
+
+	/**
+	 * Locate a template.
+	 *
+	 * @author  WebDevStudios <contact@webdevstudios.com>
+	 * @since   1.8.0-dev
+	 *
+	 * @param string $file The template file.
+	 *
+	 * @return string Full path to the template file.
+	 */
+	public static function locate_template( $file ) {
+
+		$locations = [
+			$file,
+		];
+
+		$templates_path = self::get_filtered_theme_templates_dirname();
+
+		if ( self::get_theme_templates_dirname() !== $templates_path ) {
+			$locations[] = self::get_theme_templates_dirname() . $file;
+		}
+
+		$locations[] = $templates_path . $file;
+
+		/**
+		 * Allow developers to override the template locations.
+		 *
+		 * @todo Should this even be allowed?
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param array  $locations Array of template locations.
+		 * @param string $file      The template file.
+		 */
+		$locations = (array) apply_filters(
+			'algolia_template_locations',
+			$locations,
+			$file
+		);
+
+		$template = locate_template(
+			array_unique( $locations )
+		);
+
+		$filtered_default = self::get_filtered_default_template( $file );
+
+		return (string) $template ? $template : $filtered_default;
+	}
+
+	/**
+	 * Retrieve template version.
+	 *
+	 * Based on WooCommerce's WC_Admin_Status::get_file_version() method.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @param string $template Full path to the template file.
+	 *
+	 * @return string
+	 */
+	public static function get_version( $template ): ?string {
+
+		// Null, if template file does not exist or cannot be read.
+		if ( ! is_file( $template ) || ! is_readable( $template ) ) {
+			return null;
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen
+		$pointer = fopen( $template, 'r' );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fread
+		$file_data = fread( $pointer, 8192 );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose
+		fclose( $pointer );
+
+		$file_data = str_replace( "\r", "\n", $file_data );
+
+		// Empty string, if version cannot be determined.
+		$version = '';
+
+		preg_match(
+			'/^[ \t\/*#@]*' . preg_quote( '@version', '/' ) . '(.*)$/mi',
+			$file_data,
+			$matches
+		);
+
+		if ( empty( $matches[1] ) ) {
+			return $version;
+		}
+
+		return _cleanup_header_comment( $matches[1] );
+	}
+}

--- a/includes/utilities/class-algolia-template-utils.php
+++ b/includes/utilities/class-algolia-template-utils.php
@@ -2,21 +2,21 @@
 /**
  * Algolia_Template_Utils class file.
  *
- * @since   1.8.0-dev
+ * @since   1.8.0
  * @package WebDevStudios\WPSWA
  */
 
 /**
  * Class Algolia_Template_Utils
  *
- * @since 1.8.0-dev
+ * @since 1.8.0
  */
 class Algolia_Template_Utils {
 
 	/**
 	 * The plugin template directory name.
 	 *
-	 * @since 1.8.0-dev
+	 * @since 1.8.0
 	 *
 	 * @var string
 	 */
@@ -25,7 +25,7 @@ class Algolia_Template_Utils {
 	/**
 	 * The theme template directory name.
 	 *
-	 * @since 1.8.0-dev
+	 * @since 1.8.0
 	 *
 	 * @var string
 	 */
@@ -34,7 +34,7 @@ class Algolia_Template_Utils {
 	/**
 	 * The template file names.
 	 *
-	 * @since 1.8.0-dev
+	 * @since 1.8.0
 	 *
 	 * @var string[]
 	 */
@@ -47,7 +47,7 @@ class Algolia_Template_Utils {
 	 * Get the plugin templates directory with trailing slash.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  1.8.0-dev
+	 * @since  1.8.0
 	 *
 	 * @return string The plugin templates directory name with trailing slash.
 	 */
@@ -59,7 +59,7 @@ class Algolia_Template_Utils {
 	 * Get the "unfiltered" theme templates directory with trailing slash.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  1.8.0-dev
+	 * @since  1.8.0
 	 *
 	 * @return string The theme templates directory name with trailing slash.
 	 */
@@ -71,7 +71,7 @@ class Algolia_Template_Utils {
 	 * Get the "filtered" theme templates directory name with trailing slash.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  1.8.0-dev
+	 * @since  1.8.0
 	 *
 	 * @return string The theme templates directory name with trailing slash.
 	 */
@@ -83,7 +83,7 @@ class Algolia_Template_Utils {
 		 * Allow developers to override the theme templates dirname.
 		 *
 		 * @since      1.0.0
-		 * @deprecated 1.8.0-dev Use {@see 'algolia_theme_templates_dirname'} instead.
+		 * @deprecated 1.8.0 Use {@see 'algolia_theme_templates_dirname'} instead.
 		 *
 		 * @param string $path The theme templates directory name with trailing slash.
 		 *                     Defaults to 'algolia/'.
@@ -91,14 +91,14 @@ class Algolia_Template_Utils {
 		$path = (string) apply_filters_deprecated(
 			'algolia_templates_path',
 			[ $path ],
-			'1.8.0-dev',
+			'1.8.0',
 			'algolia_theme_templates_dirname'
 		);
 
 		/**
 		 * Allow developers to override the theme templates dirname.
 		 *
-		 * @since  1.8.0-dev
+		 * @since  1.8.0
 		 *
 		 * @param string $path The theme templates directory name with trailing slash.
 		 *                     Defaults to 'algolia/'.
@@ -113,7 +113,7 @@ class Algolia_Template_Utils {
 	 * Get the "unfiltered" full path to the default template file in the plugin.
 	 *
 	 * @author  WebDevStudios <contact@webdevstudios.com>
-	 * @since   1.8.0-dev
+	 * @since   1.8.0
 	 *
 	 * @param string $file The template filename.
 	 *
@@ -127,7 +127,7 @@ class Algolia_Template_Utils {
 	 * Get the "filtered" full path to the default template file in the plugin.
 	 *
 	 * @author  WebDevStudios <contact@webdevstudios.com>
-	 * @since   1.8.0-dev
+	 * @since   1.8.0
 	 *
 	 * @param string $file The template filename.
 	 *
@@ -159,7 +159,7 @@ class Algolia_Template_Utils {
 	 * to find where a "customized" template actually exists.
 	 *
 	 * @author  WebDevStudios <contact@webdevstudios.com>
-	 * @since   1.8.0-dev
+	 * @since   1.8.0
 	 *
 	 * @param string $file The template file.
 	 *
@@ -210,7 +210,7 @@ class Algolia_Template_Utils {
 	 * Based on WooCommerce's WC_Admin_Status::get_file_version() method.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  1.8.0-dev
+	 * @since  1.8.0
 	 *
 	 * @param string $template Full path to the template file.
 	 *
@@ -256,7 +256,7 @@ class Algolia_Template_Utils {
 	 * Get the Alglia Template File Names.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  1.8.0-dev
+	 * @since  1.8.0
 	 *
 	 * @return array
 	 */
@@ -268,7 +268,7 @@ class Algolia_Template_Utils {
 	 * Get unfiltered array of plugin's core template paths.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  1.8.0-dev
+	 * @since  1.8.0
 	 *
 	 * @return array An array of the plugin's core template paths.
 	 */
@@ -293,7 +293,7 @@ class Algolia_Template_Utils {
 	 * they might be the same as the plugin's core templates.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  1.8.0-dev
+	 * @since  1.8.0
 	 *
 	 * @return array
 	 */
@@ -313,7 +313,7 @@ class Algolia_Template_Utils {
 	 * Diffs the plugin's core template paths against the located template paths.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  1.8.0-dev
+	 * @since  1.8.0
 	 *
 	 * @return array Array of custom template paths,
 	 *               else empty array if no custom templates found.

--- a/includes/utilities/class-algolia-update-messages.php
+++ b/includes/utilities/class-algolia-update-messages.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Algolia_Update_Messages class file.
+ *
+ * @author  WebDevStudios <contact@webdevstudios.com>
+ * @since   1.8.0-dev
+ *
+ * @package WebDevStudios\WPSWA
+ */
+
+/**
+ * Class Algolia_Update_Messages
+ *
+ * @since 1.8.0-dev
+ */
+class Algolia_Update_Messages {
+
+	/**
+	 * Constructor.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 */
+	public function __construct() {
+		add_action(
+			'in_plugin_update_message-' . ALGOLIA_PLUGIN_BASENAME,
+			[ $this, 'in_plugin_update_message' ],
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Update notice.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @param array  $plugin_data {
+	 *     An array of plugin metadata.
+	 *
+	 *     @type string $name        The human-readable name of the plugin.
+	 *     @type string $plugin_uri  Plugin URI.
+	 *     @type string $version     Plugin version.
+	 *     @type string $description Plugin description.
+	 *     @type string $author      Plugin author.
+	 *     @type string $author_uri  Plugin author URI.
+	 *     @type string $text_domain Plugin text domain.
+	 *     @type string $domain_path Relative path to the plugin's .mo file(s).
+	 *     @type bool   $network     Whether the plugin can only be activated network wide.
+	 *     @type string $title       The human-readable title of the plugin.
+	 *     @type string $author_name Plugin author's name.
+	 *     @type bool   $update      Whether there's an available update. Default null.
+	 * }
+	 *
+	 * @param object $response {
+	 *     An array of metadata about the available plugin update.
+	 *
+	 *     @type int    $id          Plugin ID.
+	 *     @type string $slug        Plugin slug.
+	 *     @type string $new_version New plugin version.
+	 *     @type string $url         Plugin URL.
+	 *     @type string $package     Plugin update package URL.
+	 * }
+	 *
+	 * @return void
+	 */
+	public function in_plugin_update_message( $plugin_data, $response ) {
+
+		$h4_open  = '<h4 class="update-available">';
+		$h4_close = '</h4>';
+
+		$ul_open  = '<ul class="update-available">';
+		$ul_close = '</ul>';
+
+		$changelist = '';
+
+		$current_major_version = Algolia_Version_Utils::get_major_version(
+			$plugin_data['Version']
+		);
+
+		$new_major_version = Algolia_Version_Utils::get_major_version(
+			$response->new_version
+		);
+
+		if ( $current_major_version === $new_major_version ) {
+			return;
+		}
+
+		$update_title = sprintf(
+			/* translators: placeholder 1 is current plugin version, placeholder 2 is the available update version. */
+			esc_html__( 'This is a major version update, from %1$s to %2$s, which may contain backwards incompatible changes.', 'wp-search-with-algolia' ),
+			$plugin_data['Version'],
+			$response->new_version
+		);
+
+		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+
+		$plugin_information = plugins_api(
+			'plugin_information',
+			[ 'slug' => $response->slug ]
+		);
+
+		if (
+			! $plugin_information
+			|| is_wp_error( $plugin_information )
+			|| empty( $plugin_information->sections['changelog'] )
+		) {
+			echo wp_kses_post( $h4_open . $update_title . $h4_close );
+			return;
+		}
+
+		$changelog = $plugin_information->sections['changelog'];
+
+		$changes = preg_replace( '#<\s*?p\b[^>]*>(.*?)</p\b[^>]*>#s', '', $changelog );
+
+		$pos = stripos( $changes, '<h4>' . $plugin_data['Version'] . '</h4>' );
+
+		if ( false === $pos ) {
+			echo wp_kses_post( $h4_open . $update_title . $h4_close );
+			return;
+		}
+
+		$changes = trim( substr( $changes, 0, $pos ) );
+
+		$changes = preg_replace( '/<h4>(.*)<\/h4>.*/iU', '', $changes );
+
+		$changelist .= $ul_open . strip_tags( $changes, '<li>' ) . $ul_close;
+
+		echo wp_kses_post( $h4_open . $update_title . $h4_close . $changelist );
+	}
+}

--- a/includes/utilities/class-algolia-update-messages.php
+++ b/includes/utilities/class-algolia-update-messages.php
@@ -3,7 +3,7 @@
  * Algolia_Update_Messages class file.
  *
  * @author  WebDevStudios <contact@webdevstudios.com>
- * @since   1.8.0-dev
+ * @since   1.8.0
  *
  * @package WebDevStudios\WPSWA
  */
@@ -11,7 +11,7 @@
 /**
  * Class Algolia_Update_Messages
  *
- * @since 1.8.0-dev
+ * @since 1.8.0
  */
 class Algolia_Update_Messages {
 
@@ -19,7 +19,7 @@ class Algolia_Update_Messages {
 	 * Constructor.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  1.8.0-dev
+	 * @since  1.8.0
 	 */
 	public function __construct() {
 		add_action(
@@ -34,7 +34,7 @@ class Algolia_Update_Messages {
 	 * Update notice.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  1.8.0-dev
+	 * @since  1.8.0
 	 *
 	 * @param array  $plugin_data {
 	 *     An array of plugin metadata.

--- a/includes/utilities/class-algolia-version-utils.php
+++ b/includes/utilities/class-algolia-version-utils.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Algolia_Version_Utils class file.
+ *
+ * @author  WebDevStudios <contact@webdevstudios.com>
+ * @since   1.8.0-dev
+ *
+ * @package WebDevStudios\WPSWA
+ */
+
+/**
+ * Class Algolia_Version_Utils
+ *
+ * @since 1.8.0-dev
+ */
+class Algolia_Version_Utils {
+
+	/**
+	 * Semantic versioning regular expression pattern.
+	 *
+	 * @link https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+	 * @link https://regex101.com/r/Ly7O1x/3/
+	 *
+	 * @since   1.8.0-dev
+	 *
+	 * @var string
+	 */
+	const SEMVER_PATTERN = '%^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$%';
+
+	/**
+	 * Parse version string into array of semver components.
+	 *
+	 * Supports MAJOR.MINOR.PATCH-prerelease+buildmetadata.
+	 * Given a valid semantic version string, such as '1.8.0-dev+build.1',
+	 * will return an array of matches that follow Semantic Versioning 2.0.0.
+	 * Example return...
+	 *     $matches = [
+	 *         0               => '1.8.0-dev+build.1',
+	 *         'major'         => '1',
+	 *         1               => '1',
+	 *         'minor'         => '8',
+	 *         2               => '8',
+	 *         'patch'         => '0',
+	 *         3               => '0',
+	 *         'prerelease'    => 'dev',
+	 *         4               => 'dev',
+	 *         'buildmetadata' => 'build.1',
+	 *         5               => 'build.1',
+	 *     ];
+	 *
+	 * @link https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @param string $version Version number string.
+	 *
+	 * @return array
+	 */
+	public static function parse_semver_version_string( string $version ): array {
+		$matches = [];
+		preg_match(
+			self::SEMVER_PATTERN,
+			$version,
+			$matches
+		);
+
+		return $matches;
+	}
+
+	/**
+	 * Get the MAJOR version number from version string.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @param string $version Version number string.
+	 *
+	 * @return int|null
+	 */
+	public static function get_major_version( string $version ): ?int {
+		$matches = self::parse_semver_version_string( $version );
+		if ( empty( $matches['major'] ) ) {
+			return null;
+		}
+
+		return (int) $matches['major'];
+	}
+
+	/**
+	 * Get the MINOR version number from version string.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @param string $version Version number string.
+	 *
+	 * @return int|null
+	 */
+	public static function get_minor_version( string $version ): ?int {
+		$matches = self::parse_semver_version_string( $version );
+		if ( empty( $matches['minor'] ) ) {
+			return null;
+		}
+
+		return (int) $matches['minor'];
+	}
+
+	/**
+	 * Get the PATCH version number from version string.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.8.0-dev
+	 *
+	 * @param string $version Version number string.
+	 *
+	 * @return int|null
+	 */
+	public static function get_patch_version( string $version ): ?int {
+		$matches = self::parse_semver_version_string( $version );
+		if ( empty( $matches['patch'] ) ) {
+			return null;
+		}
+
+		return (int) $matches['patch'];
+	}
+}

--- a/includes/utilities/class-algolia-version-utils.php
+++ b/includes/utilities/class-algolia-version-utils.php
@@ -3,7 +3,7 @@
  * Algolia_Version_Utils class file.
  *
  * @author  WebDevStudios <contact@webdevstudios.com>
- * @since   1.8.0-dev
+ * @since   1.8.0
  *
  * @package WebDevStudios\WPSWA
  */
@@ -11,7 +11,7 @@
 /**
  * Class Algolia_Version_Utils
  *
- * @since 1.8.0-dev
+ * @since 1.8.0
  */
 class Algolia_Version_Utils {
 
@@ -21,7 +21,7 @@ class Algolia_Version_Utils {
 	 * @link https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
 	 * @link https://regex101.com/r/Ly7O1x/3/
 	 *
-	 * @since   1.8.0-dev
+	 * @since   1.8.0
 	 *
 	 * @var string
 	 */
@@ -51,7 +51,7 @@ class Algolia_Version_Utils {
 	 * @link https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  1.8.0-dev
+	 * @since  1.8.0
 	 *
 	 * @param string $version Version number string.
 	 *
@@ -72,7 +72,7 @@ class Algolia_Version_Utils {
 	 * Get the MAJOR version number from version string.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  1.8.0-dev
+	 * @since  1.8.0
 	 *
 	 * @param string $version Version number string.
 	 *
@@ -91,7 +91,7 @@ class Algolia_Version_Utils {
 	 * Get the MINOR version number from version string.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  1.8.0-dev
+	 * @since  1.8.0
 	 *
 	 * @param string $version Version number string.
 	 *
@@ -110,7 +110,7 @@ class Algolia_Version_Utils {
 	 * Get the PATCH version number from version string.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  1.8.0-dev
+	 * @since  1.8.0
 	 *
 	 * @param string $version Version number string.
 	 *

--- a/languages/wp-search-with-algolia.pot
+++ b/languages/wp-search-with-algolia.pot
@@ -1,406 +1,341 @@
-#, fuzzy
+# Copyright (C) 2021 WebDevStudios
+# This file is distributed under the same license as the WP Search with Algolia plugin.
 msgid ""
 msgstr ""
-"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
-"Project-Id-Version: WP Search with Algolia\n"
-"POT-Creation-Date: 2020-04-17 19:11-0500\n"
-"PO-Revision-Date: 2019-08-30 22:52-0500\n"
-"Last-Translator: Richard Aber <richard.aber@webdevstudios.com>\n"
-"Language-Team: Richard Aber <richard.aber@webdevstudios.com>\n"
+"Project-Id-Version: WP Search with Algolia 1.8.0\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wp-search-with-algolia\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.3\n"
-"X-Poedit-Basepath: ..\n"
-"X-Poedit-Flags-xgettext: --add-comments=translators:\n"
-"X-Poedit-WPHeader: algolia.php\n"
-"X-Poedit-SourceCharset: UTF-8\n"
-"X-Poedit-KeywordsList: __;_e;_n:1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;esc_attr__;"
-"esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c;_n_noop:1,2;"
-"_nx_noop:3c,1,2;__ngettext_noop:1,2\n"
-"X-Poedit-SearchPath-0: .\n"
-"X-Poedit-SearchPathExcluded-0: *.min.js\n"
+"POT-Creation-Date: 2021-05-01T00:02:34+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.4.0\n"
+"X-Domain: wp-search-with-algolia\n"
+
+#. Plugin Name of the plugin
+msgid "WP Search with Algolia"
+msgstr ""
+
+#. Plugin URI of the plugin
+msgid "https://github.com/WebDevStudios/wp-search-with-algolia"
+msgstr ""
+
+#. Description of the plugin
+msgid "Integrate the powerful Algolia search service with WordPress"
+msgstr ""
+
+#. Author of the plugin
+msgid "WebDevStudios"
+msgstr ""
+
+#. Author URI of the plugin
+msgid "https://webdevstudios.com"
+msgstr ""
 
 #. translators: placeholder 1 is minimum required PHP version, placeholder 2 is installed PHP version.
-#: algolia.php:77
-#, php-format
+#: algolia.php:88
 msgid "Algolia plugin requires PHP %1$s or higher. You’re still on %2$s."
 msgstr ""
 
 #. translators: placeholder 1 is minimum required WordPress version, placeholder 2 is installed WordPress version.
-#: algolia.php:86
-#, php-format
-msgid ""
-"Algolia plugin requires at least WordPress in version %1$s, You are on %2$s."
+#: algolia.php:97
+msgid "Algolia plugin requires at least WordPress in version %1$s, You are on %2$s."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-autocomplete.php:53
-#: includes/admin/class-algolia-admin-page-settings.php:63
+#: includes/admin/class-algolia-admin-page-autocomplete.php:106
+#: includes/admin/class-algolia-admin-page-settings.php:119
 msgid "Algolia Search"
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-autocomplete.php:61
-#: includes/admin/class-algolia-admin-page-autocomplete.php:62
+#: includes/admin/class-algolia-admin-page-autocomplete.php:114
+#: includes/admin/class-algolia-admin-page-autocomplete.php:115
 msgid "Autocomplete"
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-autocomplete.php:79
+#: includes/admin/class-algolia-admin-page-autocomplete.php:138
 msgid "Enable autocomplete"
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-autocomplete.php:87
+#: includes/admin/class-algolia-admin-page-autocomplete.php:146
 msgid "Configuration"
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-autocomplete.php:120
-msgid ""
-"Autocomplete configuration has been saved. Make sure to hit the \"re-index\" "
-"buttons of the different indices that are not indexed yet."
+#: includes/admin/class-algolia-admin-page-autocomplete.php:187
+msgid "Autocomplete configuration has been saved. Make sure to hit the \"re-index\" buttons of the different indices that are not indexed yet."
 msgstr ""
 
 #. translators: placeholder contains the URL to the autocomplete configuration page.
-#: includes/admin/class-algolia-admin-page-autocomplete.php:159
-#, php-format
-msgid ""
-"Please select one or multiple indices on the <a href=\"%s\">Algolia: "
-"Autocomplete configuration page</a>."
+#: includes/admin/class-algolia-admin-page-autocomplete.php:250
+msgid "Please select one or multiple indices on the <a href=\"%s\">Algolia: Autocomplete configuration page</a>."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-autocomplete.php:161
-msgid ""
-"You have enabled the Algolia Autocomplete feature but did not choose any "
-"index to search in."
+#: includes/admin/class-algolia-admin-page-autocomplete.php:252
+msgid "You have enabled the Algolia Autocomplete feature but did not choose any index to search in."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-autocomplete.php:171
-msgid ""
-"The autocomplete feature adds a find-as-you-type dropdown menu to your "
-"search bar(s)."
+#: includes/admin/class-algolia-admin-page-autocomplete.php:265
+msgid "The autocomplete feature adds a find-as-you-type dropdown menu to your search bar(s)."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-native-search.php:44
-#: includes/admin/class-algolia-admin-page-native-search.php:45
+#: includes/admin/class-algolia-admin-page-native-search.php:93
+#: includes/admin/class-algolia-admin-page-native-search.php:94
 msgid "Search Page"
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-native-search.php:62
+#: includes/admin/class-algolia-admin-page-native-search.php:117
 msgid "Search results"
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-native-search.php:88
+#: includes/admin/class-algolia-admin-page-native-search.php:154
 msgid "WordPress search is now based on Algolia!"
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-native-search.php:95
+#: includes/admin/class-algolia-admin-page-native-search.php:161
 msgid "WordPress search is now based on Algolia instantsearch.js!"
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-native-search.php:103
-msgid ""
-"You chose to keep the WordPress native search instead of Algolia. If you are "
-"using the autocomplete feature of the plugin we highly recommend you turn "
-"Algolia search on instead of the WordPress native search."
+#: includes/admin/class-algolia-admin-page-native-search.php:169
+msgid "You chose to keep the WordPress native search instead of Algolia. If you are using the autocomplete feature of the plugin we highly recommend you turn Algolia search on instead of the WordPress native search."
 msgstr ""
 
 #. translators: placeholder contains the link to the indexing page.
-#: includes/admin/class-algolia-admin-page-native-search.php:139
-#, php-format
-msgid ""
-"Searchable posts index needs to be checked on the <a href=\"%s\">Algolia: "
-"Indexing page</a> for the search results to be powered by Algolia."
+#: includes/admin/class-algolia-admin-page-native-search.php:213
+msgid "Searchable posts index needs to be checked on the <a href=\"%s\">Algolia: Indexing page</a> for the search results to be powered by Algolia."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-native-search.php:150
-msgid ""
-"By enabling this plugin to override the native WordPress search, your search "
-"results will be powered by Algolia's typo-tolerant & relevant search "
-"algorithms."
+#: includes/admin/class-algolia-admin-page-native-search.php:227
+msgid "By enabling this plugin to override the native WordPress search, your search results will be powered by Algolia's typo-tolerant & relevant search algorithms."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-native-search.php:162
-msgid ""
-"You have no index containing only posts yet. Please index some content on "
-"the `Indexing` page."
+#: includes/admin/class-algolia-admin-page-native-search.php:239
+msgid "You have no index containing only posts yet. Please index some content on the `Indexing` page."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-settings.php:52
-#: includes/admin/class-algolia-admin-page-settings.php:73
-#: includes/admin/class-algolia-admin-page-settings.php:74
+#: includes/admin/class-algolia-admin-page-settings.php:100
+#: includes/admin/class-algolia-admin-page-settings.php:129
+#: includes/admin/class-algolia-admin-page-settings.php:130
 msgid "Settings"
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-settings.php:91
+#: includes/admin/class-algolia-admin-page-settings.php:153
 msgid "Application ID"
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-settings.php:99
+#: includes/admin/class-algolia-admin-page-settings.php:161
 msgid "Search-only API key"
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-settings.php:107
+#: includes/admin/class-algolia-admin-page-settings.php:169
 msgid "Admin API key"
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-settings.php:115
+#: includes/admin/class-algolia-admin-page-settings.php:177
 msgid "Index name prefix"
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-settings.php:123
+#: includes/admin/class-algolia-admin-page-settings.php:185
 msgid "Remove Algolia powered by logo"
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-settings.php:143
+#: includes/admin/class-algolia-admin-page-settings.php:211
 msgid "Your Algolia Application ID."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-settings.php:154
+#: includes/admin/class-algolia-admin-page-settings.php:228
 msgid "Your Algolia Search-only API key (public)."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-settings.php:164
+#: includes/admin/class-algolia-admin-page-settings.php:244
 msgid "Your Algolia ADMIN API key (kept private)."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-settings.php:174
+#: includes/admin/class-algolia-admin-page-settings.php:260
 msgid "This prefix will be prepended to your index names."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-settings.php:185
-msgid ""
-"This will remove the Algolia logo from the autocomplete and the search page. "
-"We require that you keep the Algolia logo if you are using a free plan."
+#: includes/admin/class-algolia-admin-page-settings.php:277
+msgid "This will remove the Algolia logo from the autocomplete and the search page. We require that you keep the Algolia logo if you are using a free plan."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-settings.php:198
+#: includes/admin/class-algolia-admin-page-settings.php:300
 msgid "Application ID should not be empty."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-settings.php:216
+#: includes/admin/class-algolia-admin-page-settings.php:328
 msgid "Search-only API key should not be empty."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-settings.php:233
+#: includes/admin/class-algolia-admin-page-settings.php:355
 msgid "API key should not be empty"
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-settings.php:260
-msgid ""
-"We were unable to authenticate you against the Algolia servers with the "
-"provided information. Please ensure that you used an the Admin API key and a "
-"valid Application ID."
+#: includes/admin/class-algolia-admin-page-settings.php:384
+msgid "We were unable to authenticate you against the Algolia servers with the provided information. Please ensure that you used a valid Application ID and Admin API key."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-settings.php:271
-msgid ""
-"It looks like your search API key is wrong. Ensure that the key you entered "
-"has only the search capability and nothing else. Also ensure that the key "
-"has no limited time validity."
+#: includes/admin/class-algolia-admin-page-settings.php:395
+msgid "It looks like your search API key is wrong. Ensure that the key you entered has only the search capability and nothing else. Also ensure that the key has no limited time validity."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-settings.php:280
-msgid ""
-"We succesfully managed to connect to the Algolia servers with the provided "
-"information. Your search API key has also been checked and is OK."
+#: includes/admin/class-algolia-admin-page-settings.php:405
+msgid "We succesfully managed to connect to the Algolia servers with the provided information. Your search API key has also been checked and is OK."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-settings.php:318
-msgid ""
-"Indices prefix can only contain alphanumeric characters and underscores."
+#: includes/admin/class-algolia-admin-page-settings.php:453
+msgid "Indices prefix can only contain alphanumeric characters and underscores."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-settings.php:347
-msgid ""
-"Configure your Algolia account credentials. You can find them in the \"API "
-"Keys\" section of your Algolia dashboard."
+#: includes/admin/class-algolia-admin-page-settings.php:502
+msgid "Configure your Algolia account credentials. You can find them in the \"API Keys\" section of your Algolia dashboard."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-settings.php:348
-msgid ""
-"Once you provide your Algolia Application ID and API key, this plugin will "
-"be able to securely communicate with Algolia servers."
+#: includes/admin/class-algolia-admin-page-settings.php:503
+msgid "Once you provide your Algolia Application ID and API key, this plugin will be able to securely communicate with Algolia servers."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-settings.php:348
-msgid ""
-"We ensure your information is correct by testing them against the Algolia "
-"servers upon save."
+#: includes/admin/class-algolia-admin-page-settings.php:503
+msgid "We ensure your information is correct by testing them against the Algolia servers upon save."
 msgstr ""
 
 #. translators: the placeholder contains the URL to Algolia's website.
-#: includes/admin/class-algolia-admin-page-settings.php:350
-#, php-format
-msgid ""
-"No Algolia account yet? <a href=\"%s\">Follow this link</a> to create one "
-"for free in a couple of minutes!"
+#: includes/admin/class-algolia-admin-page-settings.php:505
+msgid "No Algolia account yet? <a href=\"%s\">Follow this link</a> to create one for free in a couple of minutes!"
 msgstr ""
 
-#: includes/admin/class-algolia-admin.php:57
-msgid ""
-"Algolia Search requires the \"mbstring\" PHP extension to be enabled. Please "
-"contact your hosting provider."
+#. translators: placeholder 1 is template filename, placeholder 2 is custom template version, placeholder 3 is core template version.
+#: includes/admin/class-algolia-admin-template-notices.php:64
+msgid "Your custom WP Search With Algolia template file, %1$s, version %2$s is out of date. The core version is %3$s"
 msgstr ""
 
-#: includes/admin/class-algolia-admin.php:61
-msgid ""
-"Algolia needs \"mbregex\" NOT to be disabled. Please contact your hosting "
-"provider."
+#: includes/admin/class-algolia-admin-template-notices.php:69
+msgid "unknown"
 msgstr ""
 
-#: includes/admin/class-algolia-admin.php:67
-msgid ""
-"Algolia Search requires the \"cURL\" PHP extension to be enabled. Please "
-"contact your hosting provider."
+#: includes/admin/class-algolia-admin.php:113
+msgid "Algolia Search requires the \"mbstring\" PHP extension to be enabled. Please contact your hosting provider."
+msgstr ""
+
+#: includes/admin/class-algolia-admin.php:117
+msgid "Algolia needs \"mbregex\" NOT to be disabled. Please contact your hosting provider."
+msgstr ""
+
+#: includes/admin/class-algolia-admin.php:123
+msgid "Algolia Search requires the \"cURL\" PHP extension to be enabled. Please contact your hosting provider."
 msgstr ""
 
 #. translators: placeholder contains the URL to the caching plugin's config page.
-#: includes/admin/class-algolia-admin.php:90
-#, php-format
-msgid ""
-"In order for <strong>database caching</strong> to work with Algolia you must "
-"add <code>algolia_</code> to the \"Ignored Query Stems\" option in W3 Total "
-"Cache settings <a href=\"%s\">here</a>."
+#: includes/admin/class-algolia-admin.php:151
+msgid "In order for <strong>database caching</strong> to work with Algolia you must add <code>algolia_</code> to the \"Ignored Query Stems\" option in W3 Total Cache settings <a href=\"%s\">here</a>."
 msgstr ""
 
-#: includes/admin/class-algolia-admin.php:124
-#, php-format
-msgid ""
-"For Algolia search to work properly, you need to index: <strong>%1$s</strong>"
+#. Translators: placeholder is an Algolia index name.
+#: includes/admin/class-algolia-admin.php:188
+msgid "For Algolia search to work properly, you need to index: <strong>%1$s</strong>"
 msgstr ""
 
-#: includes/admin/class-algolia-admin.php:133
+#: includes/admin/class-algolia-admin.php:197
 msgid "Index now"
 msgstr ""
 
-#: includes/admin/partials/form-override-search-option.php:5
+#: includes/admin/partials/form-override-search-option.php:17
 msgid "Do not use Algolia"
 msgstr ""
 
-#: includes/admin/partials/form-override-search-option.php:11
-msgid ""
-"Do not use Algolia for searching at all.<br/>This is only a valid option if "
-"you wish to search on your content from another website."
+#: includes/admin/partials/form-override-search-option.php:22
+msgid "Do not use Algolia for searching at all.<br/>This is only a valid option if you wish to search on your content from another website."
 msgstr ""
 
-#: includes/admin/partials/form-override-search-option.php:24
+#: includes/admin/partials/form-override-search-option.php:36
 msgid "Use Algolia in the backend"
 msgstr ""
 
-#: includes/admin/partials/form-override-search-option.php:30
-msgid ""
-"With this option WordPress search will be powered by Algolia behind the "
-"scenes.<br/>This will allow your search results to be typo tolerant.<br/"
-"><b>This option does not support filtering and displaying instant search "
-"results but has the advantage to play nicely with any theme.</b>"
+#: includes/admin/partials/form-override-search-option.php:41
+msgid "With this option WordPress search will be powered by Algolia behind the scenes.<br/>This will allow your search results to be typo tolerant.<br/><b>This option does not support filtering and displaying instant search results but has the advantage to play nicely with any theme.</b>"
 msgstr ""
 
-#: includes/admin/partials/form-override-search-option.php:44
+#: includes/admin/partials/form-override-search-option.php:56
 msgid "Use Algolia with Instantsearch.js"
 msgstr ""
 
-#: includes/admin/partials/form-override-search-option.php:50
-msgid ""
-"This will replace the search page with an instant search experience powered "
-"by Algolia.<br/>By default you will be able to filter by post type, "
-"categories, tags and authors.<br/>Please note that the plugin is shipped "
-"with some sensible default styling rules<br/>but it could require some CSS "
-"adjustments to provide an optimal search experience."
+#: includes/admin/partials/form-override-search-option.php:61
+msgid "This will replace the search page with an instant search experience powered by Algolia.<br/>By default you will be able to filter by post type, categories, tags and authors.<br/>Please note that the plugin is shipped with some sensible default styling rules<br/>but it could require some CSS adjustments to provide an optimal search experience."
 msgstr ""
 
-#: includes/admin/partials/page-autocomplete-config.php:5
+#: includes/admin/partials/page-autocomplete-config.php:17
 msgid "Enable"
 msgstr ""
 
-#: includes/admin/partials/page-autocomplete-config.php:6
+#: includes/admin/partials/page-autocomplete-config.php:18
 msgid "Index"
 msgstr ""
 
-#: includes/admin/partials/page-autocomplete-config.php:7
+#: includes/admin/partials/page-autocomplete-config.php:19
 msgid "Label"
 msgstr ""
 
-#: includes/admin/partials/page-autocomplete-config.php:8
+#: includes/admin/partials/page-autocomplete-config.php:20
 msgid "Max. Suggestions"
 msgstr ""
 
-#: includes/admin/partials/page-autocomplete-config.php:9
+#: includes/admin/partials/page-autocomplete-config.php:21
 msgid "Actions"
 msgstr ""
 
 #. translators: placeholder is the name of an Algolia search index.
-#: includes/admin/partials/page-autocomplete-config.php:28
-#, php-format
+#: includes/admin/partials/page-autocomplete-config.php:40
 msgid "Index name: %s"
 msgstr ""
 
-#: includes/admin/partials/page-autocomplete-config.php:41
+#: includes/admin/partials/page-autocomplete-config.php:53
 msgid "Re-index"
 msgstr ""
 
-#: includes/admin/partials/page-autocomplete-config.php:42
-#: includes/admin/partials/page-search.php:5
+#: includes/admin/partials/page-autocomplete-config.php:54
+#: includes/admin/partials/page-search.php:20
 msgid "Push Settings"
 msgstr ""
 
-#: includes/admin/partials/page-autocomplete-config.php:49
+#: includes/admin/partials/page-autocomplete-config.php:61
 msgid "Configure here the indices you want to display in the dropdown menu."
 msgstr ""
 
-#: includes/admin/partials/page-autocomplete-config.php:51
-msgid ""
-"Use the `Max. Suggestions` column to configure the number of entries that "
-"will be displayed by section."
+#: includes/admin/partials/page-autocomplete-config.php:63
+msgid "Use the `Max. Suggestions` column to configure the number of entries that will be displayed by section."
 msgstr ""
 
-#: includes/admin/partials/page-autocomplete-config.php:53
-msgid ""
-"Use the `Position` column to reflect the order of the sections in the "
-"dropdown menu."
+#: includes/admin/partials/page-autocomplete-config.php:65
+msgid "Use the `Position` column to reflect the order of the sections in the dropdown menu."
 msgstr ""
 
-#: includes/admin/partials/page-search.php:4
+#: includes/admin/partials/page-search.php:17
 msgid "Re-index search page records"
 msgstr ""
 
 #. translators: the placeholder will contain the name of the index.
-#: includes/class-algolia-cli.php:77
-#, php-format
+#: includes/class-algolia-cli.php:117
 msgid "About to clear index %s..."
 msgstr ""
 
 #. translators: the placeholder will contain the name of the index.
-#: includes/class-algolia-cli.php:80
-#, php-format
+#: includes/class-algolia-cli.php:120
 msgid "Correctly cleared index \"%s\"."
 msgstr ""
 
-#: includes/indices/class-algolia-searchable-posts-index.php:35
+#: includes/indices/class-algolia-searchable-posts-index.php:78
 msgid "All posts"
 msgstr ""
 
-#: includes/indices/class-algolia-users-index.php:14
+#: includes/indices/class-algolia-users-index.php:37
 msgid "Users"
 msgstr ""
 
-#: templates/autocomplete.php:79
+#. translators: placeholder 1 is current plugin version, placeholder 2 is the available update version.
+#: includes/utilities/class-algolia-update-messages.php:92
+msgid "This is a major version update, from %1$s to %2$s, which may contain backwards incompatible changes."
+msgstr ""
+
+#: templates/autocomplete.php:91
 msgid "No results matched your query "
-msgstr ""
-
-#. Plugin Name of the plugin/theme
-msgid "WP Search with Algolia"
-msgstr ""
-
-#. Plugin URI of the plugin/theme
-msgid "https://github.com/WebDevStudios/wp-search-with-algolia"
-msgstr ""
-
-#. Description of the plugin/theme
-msgid "Integrate the powerful Algolia search service with WordPress"
-msgstr ""
-
-#. Author of the plugin/theme
-msgid "WebDevStudios"
-msgstr ""
-
-#. Author URI of the plugin/theme
-msgid "https://webdevstudios.com"
 msgstr ""


### PR DESCRIPTION
1.8.0 is ready for release.
This release is primarily focused on versioning and messaging.

* Focus on template versioning and update messaging
* Add Algolia_Template_Utils class
* Deprecate Algolia_Template_Loader::locate_template method
* Deprecate Algolia_Plugin::get_templates_path method
* Deprecate algolia_templates_path filter
* Add Algolia_Update_Messages class
* Add Algolia_Admin_Template_Notices class
* Add Algolia_Version_Utils class

Tested on WordPress 5.7.1 and PHP 8.0.0 without issue.

Testing of the admin notices and upgrade notice looks good. Though it required manipulating versions in template files, custom template files, and plugin header to trigger messages, so the information in the following example screenshots is "real", but also "simulated".

Example admin notice screenshots when custom template versions do not match WPSWA Core's template versions:
![template-notices](https://user-images.githubusercontent.com/5407441/116764995-ba6acb80-a9e8-11eb-9da2-637e4dcf017c.png)

Example plugin update screenshot when available update is a higher MAJOR version than the currently installed MAJOR version:
![major-version-update](https://user-images.githubusercontent.com/5407441/116765025-db332100-a9e8-11eb-9733-cac030f6291f.png)
