### PR TITLE
Hotfix/script dependencies

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Tags: Search, Algolia, Autocomplete, instant-search, relevant search, search hig
 Requires at least: 5.0
 Tested up to: 5.8
 Requires PHP: 7.2
-Stable tag: 2.0.0
+Stable tag: 2.0.1
 License: GNU General Public License v2.0, MIT License
 
 Improve search on your site. Autocomplete is included, along with full control over look, feel and relevance.
@@ -105,6 +105,9 @@ WebDevStudios provides end-to-end WordPress opportunities from strategy and plan
 == Changelog ==
 
 Follow along with the changelog on [Github](https://github.com/WebDevStudios/wp-search-with-algolia/releases).
+
+= 2.0.1 =
+* Fix for users that enable intstantsearch but not autocomplete by adding algoliasearch client as direct dependency of both
 
 = 2.0.0 =
 * Breaking changes for users with customized autocomplete.php / instantsearch.php template in their theme.

--- a/algolia.php
+++ b/algolia.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WP Search with Algolia
  * Plugin URI:        https://github.com/WebDevStudios/wp-search-with-algolia
  * Description:       Integrate the powerful Algolia search service with WordPress
- * Version:           2.0.0
+ * Version:           2.0.1
  * Requires at least: 5.0
  * Requires PHP:      7.2
  * Author:            WebDevStudios
@@ -26,7 +26,7 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 // The Algolia Search plugin version.
-define( 'ALGOLIA_VERSION', '2.0.0' );
+define( 'ALGOLIA_VERSION', '2.0.1' );
 
 // The minmum required PHP version.
 define( 'ALGOLIA_MIN_PHP_VERSION', '7.2' );

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "webdevstudios/wp-search-with-algolia",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Integrate the powerful Algolia search service with WordPress.",
   "authors": [
     {

--- a/includes/class-algolia-scripts.php
+++ b/includes/class-algolia-scripts.php
@@ -60,6 +60,7 @@ class Algolia_Scripts {
 				'jquery',
 				'underscore',
 				'wp-util',
+				'algolia-search',
 			],
 			ALGOLIA_VERSION,
 			$in_footer
@@ -82,6 +83,7 @@ class Algolia_Scripts {
 				'jquery',
 				'underscore',
 				'wp-util',
+				'algolia-search',
 			],
 			ALGOLIA_VERSION,
 			$in_footer

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-search-with-algolia",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Integrate the powerful Algolia search service with WordPress.",
   "author": "WebDevStudios",
   "license": "GPL-3.0",


### PR DESCRIPTION
Closes #165

@amrutadotorg reported an issue with `algoliasearch` not being defined.

@uptimizt provided additional details after experiencing the same issue, which helped narrow down the potential culprit.

Verified locally that if I configure WPSWA the same way, I could trigger the issue.

This hotfix adds the `algoliasearch` client as a direct dependency of both `autocomplete` and `instantsearch`, so that if either is enqueued, the `algoliasearch` client will also be enqueued.