### PR TITLE
Bugfix/catch reindex exception

### DIFF
--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -330,13 +330,20 @@ abstract class Algolia_Index {
 		$index = $this->get_index();
 
 		try {
-			$records = $this->sanitize_json_data( $records );
+			$sanitized_records = $this->sanitize_json_data( $records );
 		} catch ( \Throwable $throwable ) {
 			error_log( $throwable->getMessage() ); // phpcs:ignore -- Need a real logger.
 		}
 
+		// Don't saveObjects if sanitize_json_data failed.
+		if ( empty( $sanitized_records ) ) {
+			return;
+		}
+
+		$index = $this->get_index();
+
 		try {
-			$index->saveObjects( $records );
+			$index->saveObjects( $sanitized_records );
 		} catch ( \Throwable $throwable ) {
 			error_log( $throwable->getMessage() ); // phpcs:ignore -- Need a real logger.
 		}
@@ -420,16 +427,21 @@ abstract class Algolia_Index {
 		}
 
 		if ( ! empty( $records ) ) {
-			$index = $this->get_index();
 
 			try {
-				$records = $this->sanitize_json_data( $records );
+				$sanitized_records = $this->sanitize_json_data( $records );
 			} catch ( \Throwable $throwable ) {
 				error_log( $throwable->getMessage() ); // phpcs:ignore -- Need a real logger.
 			}
+		}
+
+		// Don't saveObjects if sanitize_json_data failed.
+		if ( ! empty( $sanitized_records ) ) {
+
+			$index = $this->get_index();
 
 			try {
-				$index->saveObjects( $records );
+				$index->saveObjects( $sanitized_records );
 			} catch ( \Throwable $throwable ) {
 				error_log( $throwable->getMessage() ); // phpcs:ignore -- Need a real logger.
 			}

--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -523,6 +523,8 @@ abstract class Algolia_Index {
 	 * Sanitize data to allow non UTF-8 content to pass.
 	 * Here we use a private function introduced in WP 4.1.
 	 *
+	 * Since WPSWA v 1.1.0, minimum suppported WordPress version is 5.0.
+	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
 	 * @since  1.0.0
 	 *
@@ -530,14 +532,10 @@ abstract class Algolia_Index {
 	 *
 	 * @return mixed The sanitized data that shall be encoded to JSON.
 	 *
-	 * @throws Exception If depth is less than zero.
+	 * @throws Exception If depth limit is reached.
 	 */
 	protected function sanitize_json_data( $data ) {
-		if ( function_exists( '_wp_json_sanity_check' ) ) {
-			return _wp_json_sanity_check( $data, 512 );
-		}
-
-		return $data;
+		return _wp_json_sanity_check( $data, 512 );
 	}
 
 	/**

--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -327,9 +327,19 @@ abstract class Algolia_Index {
 			return;
 		}
 
-		$index   = $this->get_index();
-		$records = $this->sanitize_json_data( $records );
-		$index->saveObjects( $records );
+		$index = $this->get_index();
+
+		try {
+			$records = $this->sanitize_json_data( $records );
+		} catch ( \Throwable $throwable ) {
+			error_log( $throwable->getMessage() ); // phpcs:ignore -- Need a real logger.
+		}
+
+		try {
+			$index->saveObjects( $records );
+		} catch ( \Throwable $throwable ) {
+			error_log( $throwable->getMessage() ); // phpcs:ignore -- Need a real logger.
+		}
 	}
 
 	/**
@@ -412,9 +422,17 @@ abstract class Algolia_Index {
 		if ( ! empty( $records ) ) {
 			$index = $this->get_index();
 
-			$records = $this->sanitize_json_data( $records );
+			try {
+				$records = $this->sanitize_json_data( $records );
+			} catch ( \Throwable $throwable ) {
+				error_log( $throwable->getMessage() ); // phpcs:ignore -- Need a real logger.
+			}
 
-			$index->saveObjects( $records );
+			try {
+				$index->saveObjects( $records );
+			} catch ( \Throwable $throwable ) {
+				error_log( $throwable->getMessage() ); // phpcs:ignore -- Need a real logger.
+			}
 		}
 
 		if ( $page === $max_num_pages ) {

--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -469,6 +469,22 @@ abstract class Algolia_Index {
 
 		if ( ! empty( $records ) ) {
 
+			/**
+			 * Filters the records to be reindexed.
+			 *
+			 * @since 2.1.0
+			 *
+			 * @param array  $records  Array of records to re-index.
+			 * @param int    $page     Page to re-index.
+			 * @param string $index_id The index ID without prefix.
+			 */
+			$records = apply_filters(
+				'algolia_re_index_records',
+				$records,
+				$page,
+				$this->get_id()
+			);
+
 			try {
 				$sanitized_records = $this->sanitize_json_data( $records );
 			} catch ( \Throwable $throwable ) {

--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -347,6 +347,22 @@ abstract class Algolia_Index {
 			return;
 		}
 
+		/**
+		 * Filters the records to be updated.
+		 *
+		 * @since 2.1.0
+		 *
+		 * @param array  $records  Array of records to update.
+		 * @param object $item     The item to update records for.
+		 * @param string $index_id The index ID without prefix.
+		 */
+		$records = apply_filters(
+			'algolia_update_records',
+			$records,
+			$item,
+			$this->get_id()
+		);
+
 		try {
 			$sanitized_records = $this->sanitize_json_data( $records );
 		} catch ( \Throwable $throwable ) {

--- a/includes/indices/class-algolia-searchable-posts-index.php
+++ b/includes/indices/class-algolia-searchable-posts-index.php
@@ -467,7 +467,7 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index {
 		return (int) get_post_meta( (int) $post_id, 'algolia_' . $this->get_id() . '_records_count', true );
 	}
 	/**
-	 * Get post records count.
+	 * Set post records count.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
 	 * @since  1.0.0


### PR DESCRIPTION
Closes #109, #175

This PR catches Throwables thrown by Algolia\AlgoliaSearch\SearchIndex::saveObjects as noted in #109 and sends their messages to error_log(), like so...
```
[31-Aug-2021 23:42:29 UTC] Record at the position 5 objectID=1196-0 is too big size=1306368/10000 bytes. Please have a look at https://www.algolia.com/doc/guides/sending-and-managing-data/prepare-your-data/in-depth/index-and-records-size-and-usage-limitations/#record-size-limits
```

This won't _prevent_ a record that is too large from being rejected, but it should at least make debugging a little easier.

This PR also sets a flag in `Algolia_Admin::re_index()` during reindexing, to prevent duplicate API calls in `Algolia_Admin::update_records()`.