### PR TITLE
Outdated HierarchicalMenu item active appearance

### DIFF
--- a/css/algolia-instantsearch.css
+++ b/css/algolia-instantsearch.css
@@ -151,6 +151,11 @@
 	font-weight: bold;
 }
 
+.ais-HierarchicalMenu-item--selected {
+	/* Hierarchical Menu: Categories */
+	font-weight: bold;
+}
+
 .ais-Menu-count,
 .ais-HierarchicalMenu-count,
 .ais-RefinementList-count {
@@ -327,11 +332,6 @@
 
 .ais-root__collapsed .ais-body, .ais-root__collapsed .ais-footer {
 	display: none;
-}
-
-/* Hierarchical Menu: Categories */
-.ais-HierarchicalMenu--item__active > div > a {
-	font-weight: bold;
 }
 
 /* Responsive */


### PR DESCRIPTION
According to latest instant search output result the CSS class of the active category link has been updated:

![image](https://user-images.githubusercontent.com/96356/137637933-a2d776e3-7b9d-4da1-8b85-45400402cfa1.png)
