### PR TITLE
Allow "resume" of indexing via CLI

### DIFF
--- a/includes/class-algolia-cli.php
+++ b/includes/class-algolia-cli.php
@@ -74,7 +74,7 @@ class Algolia_CLI extends \WP_CLI_Command {
 		$index_id  = isset( $args[0] ) ? $args[0] : null;
 		$clear     = WP_CLI\Utils\get_flag_value( $assoc_args, 'clear' );
 		$all       = WP_CLI\Utils\get_flag_value( $assoc_args, 'all' );
-		$from_page = isset( $assoc_args['from_page'] ) ? intval($assoc_args['from_page']) ? 1;
+		$from_page = isset( $assoc_args['from_page'] ) ? intval( $assoc_args['from_page'] ) ? 1;
 
 		if ( ! $index_id && ! $all ) {
 			WP_CLI::error( 'You need to either provide an index name or specify the --all argument to re-index all enabled indices.' );
@@ -115,7 +115,7 @@ class Algolia_CLI extends \WP_CLI_Command {
 	 *
 	 * @return void
 	 */
-	private function do_reindex( Algolia_Index $index, $clear, $from_page) {
+	private function do_reindex( Algolia_Index $index, $clear, $from_page ) {
 
 		if ( $clear ) {
 			/* translators: the placeholder will contain the name of the index. */
@@ -140,7 +140,7 @@ class Algolia_CLI extends \WP_CLI_Command {
 		do {
 			WP_CLI::log( sprintf('Indexing page %s.', $page );
 			$index->re_index( $page++ );
-			WP_CLI::log( sprintf('Indexed page %s.', ( $page - 1 ));
+			WP_CLI::log( sprintf('Indexed page %s.', ( $page - 1 ) );
 			$progress->tick();
 		} while ( $page <= $total_pages );
 

--- a/includes/class-algolia-cli.php
+++ b/includes/class-algolia-cli.php
@@ -51,8 +51,8 @@ class Algolia_CLI extends \WP_CLI_Command {
 	 * [--all]
 	 * : Re-indexes all the enabled indices.
 	 *
-	 * [--from_page=<from_page>]
-	 * : Re-index starting from the provided page (instead of the first page).
+	 * [--from_batch=<from_batch>]
+	 * : Re-index starting from the provided batch (instead of the first page).
 	 *
 	 * ## EXAMPLES
 	 *
@@ -74,7 +74,7 @@ class Algolia_CLI extends \WP_CLI_Command {
 		$index_id  = isset( $args[0] ) ? $args[0] : null;
 		$clear     = WP_CLI\Utils\get_flag_value( $assoc_args, 'clear' );
 		$all       = WP_CLI\Utils\get_flag_value( $assoc_args, 'all' );
-		$from_page = intval( WP_CLI\Utils\get_flag_value( $assoc_args, 'from_page', 1 ) );
+		$from_batch = intval( WP_CLI\Utils\get_flag_value( $assoc_args, 'from_batch', 1 ) );
 
 		if ( ! $index_id && ! $all ) {
 			WP_CLI::error( 'You need to either provide an index name or specify the --all argument to re-index all enabled indices.' );
@@ -99,7 +99,7 @@ class Algolia_CLI extends \WP_CLI_Command {
 		}
 
 		foreach ( $indices as $index ) {
-			$this->do_reindex( $index, $clear, $from_page );
+			$this->do_reindex( $index, $clear, $from_batch );
 		}
 	}
 
@@ -115,7 +115,7 @@ class Algolia_CLI extends \WP_CLI_Command {
 	 *
 	 * @return void
 	 */
-	private function do_reindex( Algolia_Index $index, $clear, $from_page ) {
+	private function do_reindex( Algolia_Index $index, $clear, $from_batch ) {
 
 		if ( $clear ) {
 			/* translators: the placeholder will contain the name of the index. */
@@ -134,18 +134,18 @@ class Algolia_CLI extends \WP_CLI_Command {
 			return;
 		}
 
-		$progress = WP_CLI\Utils\make_progress_bar( sprintf( 'Processing %s pages of results.', $total_pages ), $total_pages );
+		$progress = WP_CLI\Utils\make_progress_bar( sprintf( 'Processing %s batches of results.', $total_pages ), $total_pages );
 
-		$page = $from_page;
+		$page = $from_batch;
 		do {
-			WP_CLI::log( sprintf( 'Indexing page %s.', $page ) );
+			WP_CLI::log( sprintf( 'Indexing batch %s.', $page ) );
 			$index->re_index( $page++ );
-			WP_CLI::log( sprintf( 'Indexed page %s.', ( $page - 1 ) ) );
+			WP_CLI::log( sprintf( 'Indexed batch %s.', ( $page - 1 ) ) );
 			$progress->tick();
 		} while ( $page <= $total_pages );
 
 		$progress->finish();
 
-		WP_CLI::success( sprintf( 'Indexed "%s" pages of results inside index "%s"', $total_pages, $index->get_name() ) );
+		WP_CLI::success( sprintf( 'Indexed "%s" batches of results inside index "%s"', $total_pages, $index->get_name() ) );
 	}
 }

--- a/includes/class-algolia-cli.php
+++ b/includes/class-algolia-cli.php
@@ -111,7 +111,7 @@ class Algolia_CLI extends \WP_CLI_Command {
 	 *
 	 * @param Algolia_Index $index Algolia_Index instance.
 	 * @param bool          $clear Clear all existing records prior to pushing the records.
-	 * @param int           $from_page The page to start indexing from.
+	 * @param int           $from_batch The batch to start indexing from.
 	 *
 	 * @return void
 	 */
@@ -125,7 +125,7 @@ class Algolia_CLI extends \WP_CLI_Command {
 			WP_CLI::success( sprintf( __( 'Correctly cleared index "%s".', 'wp-search-with-algolia' ), $index->get_name() ) );
 		}
 
-		$total_pages = $index->get_re_index_max_num_pages() - ( $from_page - 1 );
+		$total_pages = $index->get_re_index_max_num_pages() - ( $from_batch - 1 );
 
 		if ( 0 === $total_pages ) {
 			$index->re_index( 1 );

--- a/includes/class-algolia-cli.php
+++ b/includes/class-algolia-cli.php
@@ -138,9 +138,9 @@ class Algolia_CLI extends \WP_CLI_Command {
 
 		$page = $from_page;
 		do {
-			WP_CLI::log( sprintf('Indexing page %s.', $page );
+			WP_CLI::log( sprintf( 'Indexing page %s.', $page ) );
 			$index->re_index( $page++ );
-			WP_CLI::log( sprintf('Indexed page %s.', ( $page - 1 ) );
+			WP_CLI::log( sprintf( 'Indexed page %s.', ( $page - 1 ) ) );
 			$progress->tick();
 		} while ( $page <= $total_pages );
 

--- a/includes/class-algolia-cli.php
+++ b/includes/class-algolia-cli.php
@@ -74,7 +74,7 @@ class Algolia_CLI extends \WP_CLI_Command {
 		$index_id  = isset( $args[0] ) ? $args[0] : null;
 		$clear     = WP_CLI\Utils\get_flag_value( $assoc_args, 'clear' );
 		$all       = WP_CLI\Utils\get_flag_value( $assoc_args, 'all' );
-		$from_page = isset( $assoc_args['from_page'] ) ? intval( $assoc_args['from_page'] ) ? 1;
+		$from_page = intval( WP_CLI\Utils\get_flag_value( $assoc_args, 'from_page', 1 ) );
 
 		if ( ! $index_id && ! $all ) {
 			WP_CLI::error( 'You need to either provide an index name or specify the --all argument to re-index all enabled indices.' );

--- a/includes/class-algolia-cli.php
+++ b/includes/class-algolia-cli.php
@@ -99,7 +99,7 @@ class Algolia_CLI extends \WP_CLI_Command {
 		}
 
 		foreach ( $indices as $index ) {
-			$this->do_reindex( $index, $clear, $from_page);
+			$this->do_reindex( $index, $clear, $from_page );
 		}
 	}
 

--- a/includes/class-algolia-cli.php
+++ b/includes/class-algolia-cli.php
@@ -99,7 +99,7 @@ class Algolia_CLI extends \WP_CLI_Command {
 		}
 
 		foreach ( $indices as $index ) {
-			$this->do_reindex( $index, $clear, $page);
+			$this->do_reindex( $index, $clear, $from_page);
 		}
 	}
 


### PR DESCRIPTION
On some hostings (mine for instance), the indexing process is very hard to get through. WP-CLI is often run in the browser, and has limitations on how long it is allowed to run. Other hostings provide "solutions" for running commands, but with time limits. This results in incomplete indexes, and are hard (or impossible) to solve.

With the proposed change, one can "resume" the indexing process by starting from any other "page" than the 1 st.

In order to make it simpler to know which page a user should start at, I also made some output changes. I have not been able to test this locally - but I suspect that the progress bar might break if output is written. If so, I can change the PR to make some flag to allow the user to output page numbers instead of the progress bar.