### PR TITLE
Add core WP post types and taxonomies to excluded list

### DIFF
--- a/includes/class-algolia-settings.php
+++ b/includes/class-algolia-settings.php
@@ -160,10 +160,6 @@ class Algolia_Settings {
 		$excluded[] = 'wp_template';
 		$excluded[] = 'wp_template_part';
 
-		// Native to Algolia Search plugin.
-		$excluded[] = 'algolia_task';
-		$excluded[] = 'algolia_log';
-
 		// Native to WordPress VIP platform.
 		$excluded[] = 'kr_request_token';
 		$excluded[] = 'kr_access_token';

--- a/includes/class-algolia-settings.php
+++ b/includes/class-algolia-settings.php
@@ -150,6 +150,15 @@ class Algolia_Settings {
 
 		// Native WordPress.
 		$excluded[] = 'revision';
+		$excluded[] = 'custom_css';
+		$excluded[] = 'customize_changeset';
+		$excluded[] = 'oembed_cache';
+		$excluded[] = 'user_request';
+		$excluded[] = 'wp_block';
+		$excluded[] = 'wp_global_styles';
+		$excluded[] = 'wp_navigation';
+		$excluded[] = 'wp_template';
+		$excluded[] = 'wp_template_part';
 
 		// Native to Algolia Search plugin.
 		$excluded[] = 'algolia_task';
@@ -228,6 +237,8 @@ class Algolia_Settings {
 			'nav_menu',
 			'link_category',
 			'post_format',
+			'wp_theme',
+			'wp_template_part_area',
 		];
 
 		/**


### PR DESCRIPTION
### Description

Fix #244 

This PR updates the list of excluded custom post types and taxonomies by default to include WordPress' internal data types.