### PR TITLE
[WiP] - Improving the Settings SYNC of the Primary/Replica Indices

### DIFF
--- a/classmap.php
+++ b/classmap.php
@@ -47,6 +47,8 @@ require_once ALGOLIA_PATH . 'includes/class-algolia-utils.php';
 require_once ALGOLIA_PATH . 'includes/class-algolia-styles.php';
 require_once ALGOLIA_PATH . 'includes/class-algolia-scripts.php';
 
+require_once ALGOLIA_PATH . 'includes/indices/settings/interface-algolia-index-settings.php';
+require_once ALGOLIA_PATH . 'includes/indices/settings/class-algolia-primary-index-settings.php';
 require_once ALGOLIA_PATH . 'includes/indices/class-algolia-index.php';
 require_once ALGOLIA_PATH . 'includes/indices/class-algolia-index-replica.php';
 require_once ALGOLIA_PATH . 'includes/indices/class-algolia-searchable-posts-index.php';

--- a/classmap.php
+++ b/classmap.php
@@ -49,6 +49,8 @@ require_once ALGOLIA_PATH . 'includes/class-algolia-scripts.php';
 
 require_once ALGOLIA_PATH . 'includes/indices/settings/interface-algolia-index-settings.php';
 require_once ALGOLIA_PATH . 'includes/indices/settings/class-algolia-primary-index-settings.php';
+require_once ALGOLIA_PATH . 'includes/indices/settings/class-algolia-index-settings-decorator.php';
+require_once ALGOLIA_PATH . 'includes/indices/settings/class-algolia-replica-index-settings.php';
 require_once ALGOLIA_PATH . 'includes/indices/class-algolia-index.php';
 require_once ALGOLIA_PATH . 'includes/indices/class-algolia-index-replica.php';
 require_once ALGOLIA_PATH . 'includes/indices/class-algolia-searchable-posts-index.php';

--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -18,7 +18,12 @@ use WebDevStudios\WPSWA\Algolia\AlgoliaSearch\SearchIndex;
  * @since 1.0.0
  */
 abstract class Algolia_Index {
-	protected $settings = [];
+	/**
+	 * Default index settings
+	 *
+	 * @var array
+	 */
+	protected array $default_settings = [];
 
 	/**
 	 * The SearchClient instance.
@@ -686,8 +691,8 @@ abstract class Algolia_Index {
 	 *
 	 * @return array
 	 */
-	public function get_settings() {
-		$settings = (array) apply_filters( 'algolia_' . $this->get_id() . '_index_settings', $this->settings );
+	public function get_default_settings() {
+		$settings = (array) apply_filters( 'algolia_' . $this->get_id() . '_index_settings', $this->default_settings );
 
 		/**
 		 * Replacing `attributesToIndex` with `searchableAttributes` as

--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -823,10 +823,7 @@ abstract class Algolia_Index {
 			)
 		);
 
-		$client = $this->get_client();
-
-		// Ensure we re-push the master index settings each time.
-		$settings = $this->get_settings();
+		$settings = new Algolia_Primary_Index_Settings( $this ); // TODO: maybe move a common place.
 
 		/**
 		 * Loop over the replicas.
@@ -837,10 +834,7 @@ abstract class Algolia_Index {
 		 * @var Algolia_Index_Replica $replica
 		 */
 		foreach ( $replicas as $replica ) {
-			$settings['ranking'] = $replica->get_ranking();
-			$replica_index_name  = $replica->get_replica_index_name( $this );
-			$index               = $client->initIndex( $replica_index_name );
-			$index->setSettings( $settings );
+			( new Algolia_Replica_Index_Settings( $settings, $replica ) );
 		}
 	}
 

--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -152,7 +152,7 @@ abstract class Algolia_Index {
 	 *
 	 * @throws LogicException If the SearchClient has not been set.
 	 */
-	final protected function get_client() {
+	public function get_client() {
 		if ( null === $this->client ) {
 			throw new LogicException( 'SearchClient has not been set.' );
 		}

--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -392,7 +392,6 @@ abstract class Algolia_Index {
 	 * @return SearchIndex
 	 */
 	public function get_index() {
-		ray( $this->get_name() );
 		return $this->client->initIndex( (string) $this->get_name() );
 	}
 

--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -392,6 +392,7 @@ abstract class Algolia_Index {
 	 * @return SearchIndex
 	 */
 	public function get_index() {
+		ray( $this->get_name() );
 		return $this->client->initIndex( (string) $this->get_name() );
 	}
 
@@ -686,7 +687,7 @@ abstract class Algolia_Index {
 	 *
 	 * @return array
 	 */
-	abstract protected function get_settings();
+	abstract public function get_settings();
 
 	/**
 	 * Get synonyms.

--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -579,8 +579,7 @@ abstract class Algolia_Index {
 		$index = $this->get_index();
 
 		// This will create the index if it does not exist.
-		$settings = $this->get_settings();
-		$index->setSettings( $settings );
+		( new Algolia_Primary_Index_Settings( $this ) )->push();
 
 		// Push synonyms.
 		$synonyms = $this->get_synonyms();

--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -18,6 +18,8 @@ use WebDevStudios\WPSWA\Algolia\AlgoliaSearch\SearchIndex;
  * @since 1.0.0
  */
 abstract class Algolia_Index {
+	const AC_INDEX_NOT_EXISTS_EXCEPTION_MSG = 'Index does not exist';
+
 	/**
 	 * Default index settings
 	 *

--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -18,6 +18,7 @@ use WebDevStudios\WPSWA\Algolia\AlgoliaSearch\SearchIndex;
  * @since 1.0.0
  */
 abstract class Algolia_Index {
+	protected $settings = [];
 
 	/**
 	 * The SearchClient instance.
@@ -685,7 +686,29 @@ abstract class Algolia_Index {
 	 *
 	 * @return array
 	 */
-	abstract public function get_settings();
+	public function get_settings() {
+		$settings = (array) apply_filters( 'algolia_' . $this->get_id() . '_index_settings', $this->settings );
+
+		/**
+		 * Replacing `attributesToIndex` with `searchableAttributes` as
+		 * it has been replaced by Algolia.
+		 *
+		 * @link  https://www.algolia.com/doc/api-reference/api-parameters/searchableAttributes/
+		 * @since 2.2.0
+		 */
+		if (
+			array_key_exists( 'attributesToIndex', $settings )
+			&& is_array( $settings['attributesToIndex'] )
+		) {
+			$settings['searchableAttributes'] = array_merge(
+				$settings['searchableAttributes'],
+				$settings['attributesToIndex']
+			);
+			unset( $settings['attributesToIndex'] );
+		}
+
+		return $settings;
+	}
 
 	/**
 	 * Get synonyms.

--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -11,6 +11,7 @@
 use WebDevStudios\WPSWA\Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
 use WebDevStudios\WPSWA\Algolia\AlgoliaSearch\SearchClient;
 use WebDevStudios\WPSWA\Algolia\AlgoliaSearch\SearchIndex;
+use WebDevStudios\WPSWA\Algolia\AlgoliaSearch\Exceptions\NotFoundException;
 
 /**
  * Class Algolia_Index
@@ -881,27 +882,23 @@ abstract class Algolia_Index {
 	/**
 	 * Check if the index exists in Algolia.
 	 *
-	 * Returns true if the index exists in Algolia.
-	 * false otherwise.
+	 * Returns true if the index exists in Algolia, false otherwise.
 	 *
+	 * @throws \Exception various exceptions can be thrown by Algolia Client.
 	 * @author WebDevStudios <contact@webdevstudios.com>
 	 * @since  1.0.0
 	 *
 	 * @return bool
-	 *
-	 * @throws AlgoliaException If the index does not exist in Algolia.
 	 */
 	public function exists() {
 		try {
 			$this->get_index()->getSettings();
-		} catch ( AlgoliaException $exception ) {
-			if ( $exception->getMessage() === 'Index does not exist' ) {
+		} catch ( NotFoundException $exception ) {
+			if ( self::AC_INDEX_NOT_EXISTS_EXCEPTION_MSG === $exception->getMessage() ) {
 				return false;
 			}
 
-			error_log( $exception->getMessage() ); // phpcs:ignore -- Legacy.
-
-			return false;
+			throw $exception;
 		}
 
 		return true;

--- a/includes/indices/class-algolia-posts-index.php
+++ b/includes/indices/class-algolia-posts-index.php
@@ -14,7 +14,7 @@
  * @since 1.0.0
  */
 final class Algolia_Posts_Index extends Algolia_Index {
-	protected $settings = [
+	protected array $default_settings = [
 		'searchableAttributes'  => array(
 			'unordered(post_title)',
 			'unordered(taxonomies)',
@@ -288,15 +288,16 @@ final class Algolia_Posts_Index extends Algolia_Index {
 
 	/**
 	 * Get settings.
+	 * Overridden to able to have "algolia_posts_index_settings" filter.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
 	 * @since  1.0.0
 	 *
 	 * @return array
 	 */
-	public function get_settings() {
-		$this->settings = (array) apply_filters( 'algolia_posts_index_settings', $this->settings, $this->post_type );
-		return parent::get_settings();
+	public function get_default_settings() {
+		$this->default_settings = (array) apply_filters( 'algolia_posts_index_settings', $this->default_settings, $this->post_type );
+		return parent::get_default_settings();
 	}
 
 	/**

--- a/includes/indices/class-algolia-posts-index.php
+++ b/includes/indices/class-algolia-posts-index.php
@@ -295,7 +295,8 @@ final class Algolia_Posts_Index extends Algolia_Index {
 	 * @return array
 	 */
 	public function get_settings() {
-		return (array) apply_filters( 'algolia_posts_index_settings', parent::get_settings(), $this->post_type );
+		$this->settings = (array) apply_filters( 'algolia_posts_index_settings', $this->settings, $this->post_type );
+		return parent::get_settings();
 	}
 
 	/**

--- a/includes/indices/class-algolia-posts-index.php
+++ b/includes/indices/class-algolia-posts-index.php
@@ -270,7 +270,7 @@ final class Algolia_Posts_Index extends Algolia_Index {
 	 *
 	 * @return array
 	 */
-	protected function get_settings() {
+	public function get_settings() {
 		$settings = array(
 			'searchableAttributes'  => array(
 				'unordered(post_title)',

--- a/includes/indices/class-algolia-posts-index.php
+++ b/includes/indices/class-algolia-posts-index.php
@@ -14,6 +14,30 @@
  * @since 1.0.0
  */
 final class Algolia_Posts_Index extends Algolia_Index {
+	protected $settings = [
+		'searchableAttributes'  => array(
+			'unordered(post_title)',
+			'unordered(taxonomies)',
+			'unordered(content)',
+		),
+		'customRanking'         => array(
+			'desc(is_sticky)',
+			'desc(post_date)',
+			'asc(record_index)',
+		),
+		'attributeForDistinct'  => 'post_id',
+		'distinct'              => true,
+		'attributesForFaceting' => array(
+			'taxonomies',
+			'taxonomies_hierarchical',
+			'post_author.display_name',
+		),
+		'attributesToSnippet'   => array(
+			'post_title:30',
+			'content:30',
+		),
+		'snippetEllipsisText'   => '…',
+	];
 
 	/**
 	 * The post type.
@@ -271,53 +295,7 @@ final class Algolia_Posts_Index extends Algolia_Index {
 	 * @return array
 	 */
 	public function get_settings() {
-		$settings = array(
-			'searchableAttributes'  => array(
-				'unordered(post_title)',
-				'unordered(taxonomies)',
-				'unordered(content)',
-			),
-			'customRanking'         => array(
-				'desc(is_sticky)',
-				'desc(post_date)',
-				'asc(record_index)',
-			),
-			'attributeForDistinct'  => 'post_id',
-			'distinct'              => true,
-			'attributesForFaceting' => array(
-				'taxonomies',
-				'taxonomies_hierarchical',
-				'post_author.display_name',
-			),
-			'attributesToSnippet'   => array(
-				'post_title:30',
-				'content:30',
-			),
-			'snippetEllipsisText'   => '…',
-		);
-
-		$settings = (array) apply_filters( 'algolia_posts_index_settings', $settings, $this->post_type );
-		$settings = (array) apply_filters( 'algolia_posts_' . $this->post_type . '_index_settings', $settings );
-
-		/**
-		 * Replacing `attributesToIndex` with `searchableAttributes` as
-		 * it has been replaced by Algolia.
-		 *
-		 * @link  https://www.algolia.com/doc/api-reference/api-parameters/searchableAttributes/
-		 * @since 2.2.0
-		 */
-		if (
-			array_key_exists( 'attributesToIndex', $settings )
-			&& is_array( $settings['attributesToIndex'] )
-		) {
-			$settings['searchableAttributes'] = array_merge(
-				$settings['searchableAttributes'],
-				$settings['attributesToIndex']
-			);
-			unset( $settings['attributesToIndex'] );
-		}
-
-		return $settings;
+		return (array) apply_filters( 'algolia_posts_index_settings', parent::get_settings(), $this->post_type );
 	}
 
 	/**

--- a/includes/indices/class-algolia-searchable-posts-index.php
+++ b/includes/indices/class-algolia-searchable-posts-index.php
@@ -254,7 +254,7 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index {
 	 *
 	 * @return array
 	 */
-	protected function get_settings() {
+	public function get_settings() {
 		$settings = array(
 			'searchableAttributes'  => array(
 				'unordered(post_title)',

--- a/includes/indices/class-algolia-searchable-posts-index.php
+++ b/includes/indices/class-algolia-searchable-posts-index.php
@@ -249,14 +249,15 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index {
 	/**
 	 * Get settings.
 	 *
+	 * Overridden to able to have "excerpt_length" WP filter hook for the attributesToSnippet.content
+	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
 	 * @since  1.0.0
 	 *
 	 * @return array
 	 */
-	public function get_settings() {
-		// override settings prop to inject the WP Filter Hook.
-		$this->settings = [
+	public function get_default_settings() {
+		$this->default_settings = [
 			'searchableAttributes'  => array(
 				'unordered(post_title)',
 				'unordered(taxonomies)',
@@ -282,7 +283,7 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index {
 			'snippetEllipsisText'   => '…',
 		];
 
-		return parent::get_settings();
+		return parent::get_default_settings();
 	}
 
 	/**

--- a/includes/indices/class-algolia-searchable-posts-index.php
+++ b/includes/indices/class-algolia-searchable-posts-index.php
@@ -255,7 +255,8 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index {
 	 * @return array
 	 */
 	public function get_settings() {
-		$settings = array(
+		// override settings prop to inject the WP Filter Hook.
+		$this->settings = [
 			'searchableAttributes'  => array(
 				'unordered(post_title)',
 				'unordered(taxonomies)',
@@ -279,29 +280,9 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index {
 				'content:' . intval( apply_filters( 'excerpt_length', 55 ) ), // phpcs:ignore -- Legitimate use of Core hook.
 			),
 			'snippetEllipsisText'   => '…',
-		);
+		];
 
-		$settings = (array) apply_filters( 'algolia_searchable_posts_index_settings', $settings );
-
-		/**
-		 * Replacing `attributesToIndex` with `searchableAttributes` as
-		 * it has been replaced by Algolia.
-		 *
-		 * @link  https://www.algolia.com/doc/api-reference/api-parameters/searchableAttributes/
-		 * @since 2.2.0
-		 */
-		if (
-			array_key_exists( 'attributesToIndex', $settings )
-			&& is_array( $settings['attributesToIndex'] )
-		) {
-			$settings['searchableAttributes'] = array_merge(
-				$settings['searchableAttributes'],
-				$settings['attributesToIndex']
-			);
-			unset( $settings['attributesToIndex'] );
-		}
-
-		return $settings;
+		return parent::get_settings();
 	}
 
 	/**

--- a/includes/indices/class-algolia-terms-index.php
+++ b/includes/indices/class-algolia-terms-index.php
@@ -139,7 +139,9 @@ final class Algolia_Terms_Index extends Algolia_Index {
 	 * @return array
 	 */
 	public function get_settings() {
-		return apply_filters( 'algolia_terms_index_settings', parent::get_settings(), $this->taxonomy );
+		// override settings prop to have a custom WP filter hook for terms only
+		$this->settings = apply_filters( 'algolia_terms_index_settings', $this->settings, $this->taxonomy );
+		return parent::get_settings();
 	}
 
 	/**

--- a/includes/indices/class-algolia-terms-index.php
+++ b/includes/indices/class-algolia-terms-index.php
@@ -14,6 +14,15 @@
  * @since 1.0.0
  */
 final class Algolia_Terms_Index extends Algolia_Index {
+	protected $settings = [
+		'searchableAttributes' => array(
+			'unordered(name)',
+			'unordered(description)',
+		),
+		'customRanking'        => array(
+			'desc(posts_count)',
+		),
+	];
 
 	/**
 	 * What this index contains.
@@ -130,38 +139,7 @@ final class Algolia_Terms_Index extends Algolia_Index {
 	 * @return array
 	 */
 	public function get_settings() {
-		$settings = array(
-			'searchableAttributes' => array(
-				'unordered(name)',
-				'unordered(description)',
-			),
-			'customRanking'        => array(
-				'desc(posts_count)',
-			),
-		);
-
-		$settings = (array) apply_filters( 'algolia_terms_index_settings', $settings, $this->taxonomy );
-		$settings = (array) apply_filters( 'algolia_terms_' . $this->taxonomy . '_index_settings', $settings );
-
-		/**
-		 * Replacing `attributesToIndex` with `searchableAttributes` as
-		 * it has been replaced by Algolia.
-		 *
-		 * @link  https://www.algolia.com/doc/api-reference/api-parameters/searchableAttributes/
-		 * @since 2.2.0
-		 */
-		if (
-			array_key_exists( 'attributesToIndex', $settings )
-			&& is_array( $settings['attributesToIndex'] )
-		) {
-			$settings['searchableAttributes'] = array_merge(
-				$settings['searchableAttributes'],
-				$settings['attributesToIndex']
-			);
-			unset( $settings['attributesToIndex'] );
-		}
-
-		return $settings;
+		return apply_filters( 'algolia_terms_index_settings', parent::get_settings(), $this->taxonomy );
 	}
 
 	/**

--- a/includes/indices/class-algolia-terms-index.php
+++ b/includes/indices/class-algolia-terms-index.php
@@ -129,7 +129,7 @@ final class Algolia_Terms_Index extends Algolia_Index {
 	 *
 	 * @return array
 	 */
-	protected function get_settings() {
+	public function get_settings() {
 		$settings = array(
 			'searchableAttributes' => array(
 				'unordered(name)',

--- a/includes/indices/class-algolia-terms-index.php
+++ b/includes/indices/class-algolia-terms-index.php
@@ -14,7 +14,7 @@
  * @since 1.0.0
  */
 final class Algolia_Terms_Index extends Algolia_Index {
-	protected $settings = [
+	protected array $default_settings = [
 		'searchableAttributes' => array(
 			'unordered(name)',
 			'unordered(description)',
@@ -138,10 +138,10 @@ final class Algolia_Terms_Index extends Algolia_Index {
 	 *
 	 * @return array
 	 */
-	public function get_settings() {
+	public function get_default_settings() {
 		// override settings prop to have a custom WP filter hook for terms only
-		$this->settings = apply_filters( 'algolia_terms_index_settings', $this->settings, $this->taxonomy );
-		return parent::get_settings();
+		$this->default_settings = apply_filters( 'algolia_terms_index_settings', $this->default_settings, $this->taxonomy );
+		return parent::get_default_settings();
 	}
 
 	/**

--- a/includes/indices/class-algolia-users-index.php
+++ b/includes/indices/class-algolia-users-index.php
@@ -14,7 +14,7 @@
  * @since 1.0.0
  */
 final class Algolia_Users_Index extends Algolia_Index {
-	protected $settings = [
+	protected array $default_settings = [
 		'searchableAttributes' => array(
 			'unordered(display_name)',
 		),

--- a/includes/indices/class-algolia-users-index.php
+++ b/includes/indices/class-algolia-users-index.php
@@ -121,7 +121,7 @@ final class Algolia_Users_Index extends Algolia_Index {
 	 *
 	 * @return array
 	 */
-	protected function get_settings() {
+	public function get_settings() {
 		$settings = array(
 			'searchableAttributes' => array(
 				'unordered(display_name)',

--- a/includes/indices/class-algolia-users-index.php
+++ b/includes/indices/class-algolia-users-index.php
@@ -14,6 +14,14 @@
  * @since 1.0.0
  */
 final class Algolia_Users_Index extends Algolia_Index {
+	protected $settings = [
+		'searchableAttributes' => array(
+			'unordered(display_name)',
+		),
+		'customRanking'        => array(
+			'desc(posts_count)',
+		),
+	];
 
 	/**
 	 * What this index contains.
@@ -111,47 +119,6 @@ final class Algolia_Users_Index extends Algolia_Index {
 		$users_count = count_users();
 
 		return (int) $users_count['total_users'];
-	}
-
-	/**
-	 * Get settings.
-	 *
-	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  1.0.0
-	 *
-	 * @return array
-	 */
-	public function get_settings() {
-		$settings = array(
-			'searchableAttributes' => array(
-				'unordered(display_name)',
-			),
-			'customRanking'        => array(
-				'desc(posts_count)',
-			),
-		);
-
-		$settings = (array) apply_filters( 'algolia_users_index_settings', $settings );
-
-		/**
-		 * Replacing `attributesToIndex` with `searchableAttributes` as
-		 * it has been replaced by Algolia.
-		 *
-		 * @link  https://www.algolia.com/doc/api-reference/api-parameters/searchableAttributes/
-		 * @since 2.2.0
-		 */
-		if (
-			array_key_exists( 'attributesToIndex', $settings )
-			&& is_array( $settings['attributesToIndex'] )
-		) {
-			$settings['searchableAttributes'] = array_merge(
-				$settings['searchableAttributes'],
-				$settings['attributesToIndex']
-			);
-			unset( $settings['attributesToIndex'] );
-		}
-
-		return $settings;
 	}
 
 	/**

--- a/includes/indices/settings/class-algolia-index-settings-decorator.php
+++ b/includes/indices/settings/class-algolia-index-settings-decorator.php
@@ -2,7 +2,7 @@
 
 use WebDevStudios\WPSWA\Algolia\AlgoliaSearch\SearchIndex;
 
-class Algolia_Index_Settings_Decorator implements Algolia_Index_Settings {
+abstract class Algolia_Index_Settings_Decorator implements Algolia_Index_Settings {
 	protected Algolia_Index_Settings $index_settings;
 
 	public function __construct( Algolia_Index_Settings $index_settings ) {
@@ -25,11 +25,15 @@ class Algolia_Index_Settings_Decorator implements Algolia_Index_Settings {
 		return $this->index_settings->get_remote_settings();
 	}
 
+	public function set_algolia_index(): void {
+		$this->index_settings->set_algolia_index();
+	}
+
 	public function get_settings_needs_sync(): array {
 		return $this->index_settings->get_settings_needs_sync();
 	}
 
 	public function push(): bool {
-		return $this->index_settings->get_push();
+		return $this->index_settings->push();
 	}
 }

--- a/includes/indices/settings/class-algolia-index-settings-decorator.php
+++ b/includes/indices/settings/class-algolia-index-settings-decorator.php
@@ -1,0 +1,35 @@
+<?php
+
+use WebDevStudios\WPSWA\Algolia\AlgoliaSearch\SearchIndex;
+
+class Algolia_Index_Settings_Decorator implements Algolia_Index_Settings {
+	protected Algolia_Index_Settings $index_settings;
+
+	public function __construct( Algolia_Index_Settings $index_settings ) {
+		$this->index_settings = $index_settings;
+	}
+
+	public function get_index(): Algolia_Index {
+		return $this->index_settings->get_index();
+	}
+
+	public function get_algolia_index(): SearchIndex {
+		return $this->index_settings->get_algolia_index();
+	}
+
+	public function get_local_settings(): array {
+		return $this->index_settings->get_local_settings();
+	}
+
+	public function get_remote_settings(): array {
+		return $this->index_settings->get_remote_settings();
+	}
+
+	public function get_settings_needs_sync(): array {
+		return $this->index_settings->get_settings_needs_sync();
+	}
+
+	public function push(): bool {
+		return $this->index_settings->get_push();
+	}
+}

--- a/includes/indices/settings/class-algolia-primary-index-settings.php
+++ b/includes/indices/settings/class-algolia-primary-index-settings.php
@@ -24,7 +24,7 @@ class Algolia_Primary_Index_Settings implements Algolia_Index_Settings {
 	}
 
 	public function get_local_settings(): array {
-		return $this->get_index()->get_settings();
+		return $this->get_index()->get_default_settings();
 	}
 
 	public function get_remote_settings(): array {

--- a/includes/indices/settings/class-algolia-primary-index-settings.php
+++ b/includes/indices/settings/class-algolia-primary-index-settings.php
@@ -1,0 +1,32 @@
+<?php
+
+class Algolia_Primary_Index_Settings implements Algolia_Index_Settings {
+    protected Algolia_Index $index;
+
+    public function __construct( Algolia_Index $index )
+    {
+        $this->set_index($index);
+    }
+
+    public function set_index(Algolia_Index $index ){
+        $this->index = $index;
+    }
+
+	public function get_index(): Algolia_Index {
+        return $this->index;
+    }
+
+	public function get_local_settings(): array {
+        return $this->get_index()->get_settings();
+    }
+
+	public function get_settings_needs_sync() {
+        return [
+            // TODO
+        ];
+    }
+
+	public function push(): bool {
+        return true; // TODO
+    }
+}

--- a/includes/indices/settings/class-algolia-primary-index-settings.php
+++ b/includes/indices/settings/class-algolia-primary-index-settings.php
@@ -3,64 +3,59 @@
 use WebDevStudios\WPSWA\Algolia\AlgoliaSearch\SearchIndex;
 
 class Algolia_Primary_Index_Settings implements Algolia_Index_Settings {
-    protected Algolia_Index $index;
+	protected Algolia_Index $index;
 
-    public function __construct( Algolia_Index $index )
-    {
-        $this->set_index($index);
-    }
-
-    public function set_index(Algolia_Index $index ){
-        $this->index = $index;
-    }
+	public function __construct( Algolia_Index $index ) {
+		$this->index = $index;
+	}
 
 	public function get_index(): Algolia_Index {
-        return $this->index;
-    }
+		return $this->index;
+	}
 
-    protected function get_algolia_index(): SearchIndex {
-        return $this->get_index()->get_index();
-    }
+	public function get_algolia_index(): SearchIndex {
+		return $this->get_index()->get_index();
+	}
 
 	public function get_local_settings(): array {
-        return $this->get_index()->get_settings();
-    }
+		return $this->get_index()->get_settings();
+	}
 
-    public function get_remote_settings(): array {
-        if( ! $this->get_index()->exists() ) {
-            return [];
-        }
+	public function get_remote_settings(): array {
+		if ( ! $this->get_index()->exists() ) {
+			return [];
+		}
 
-        return $this->get_algolia_index()->getSettings();
-    }
+		return $this->get_algolia_index()->getSettings();
+	}
 
 	public function get_settings_needs_sync(): array {
-        $remote_settings = $this->get_remote_settings();
+		$remote_settings = $this->get_remote_settings();
 
-        $needs_sync = [];
+		$needs_sync = [];
 
-        foreach( $this->get_local_settings() as $key=>$value ) {
-            if( ! array_key_exists( $key, $remote_settings ) || $remote_settings[$key] === null ) {
-                $needs_sync[$key] = $value;
-            }
-        }
+		foreach ( $this->get_local_settings() as $key => $value ) {
+			if ( ! array_key_exists( $key, $remote_settings ) || $remote_settings[ $key ] === null ) {
+				$needs_sync[ $key ] = $value;
+			}
+		}
 
-        return $needs_sync;
-    }
+		return $needs_sync;
+	}
 
 	public function push(): bool {
-        $settings_needs_sync = $this->get_settings_needs_sync();
+		$settings_needs_sync = $this->get_settings_needs_sync();
 
-        if( count( $settings_needs_sync ) === 0 ) {
-            return false;
-        }
+		if ( count( $settings_needs_sync ) === 0 ) {
+			return false;
+		}
 
-        try {
-            $this->get_algolia_index()->setSettings($settings_needs_sync);
-        }catch(Exception $e) {
-            return false;
-        }
+		try {
+			$this->get_algolia_index()->setSettings( $settings_needs_sync );
+		} catch ( Exception $e ) {
+			return false;
+		}
 
-        return true;
-    }
+		return true;
+	}
 }

--- a/includes/indices/settings/class-algolia-primary-index-settings.php
+++ b/includes/indices/settings/class-algolia-primary-index-settings.php
@@ -55,10 +55,12 @@ class Algolia_Primary_Index_Settings implements Algolia_Index_Settings {
             return false;
         }
 
-        $synced_settings = (array) $this->get_algolia_index()->setSettings($settings_needs_sync);
+        try {
+            $this->get_algolia_index()->setSettings($settings_needs_sync);
+        }catch(Exception $e) {
+            return false;
+        }
 
-        // TODO: maybe return a detailed response, evaluate if that's needed.
-
-        return count( $synced_settings ) > 0;
+        return true;
     }
 }

--- a/includes/indices/settings/class-algolia-primary-index-settings.php
+++ b/includes/indices/settings/class-algolia-primary-index-settings.php
@@ -49,15 +49,21 @@ class Algolia_Primary_Index_Settings implements Algolia_Index_Settings {
 		return $needs_sync;
 	}
 
-	public function push(): bool {
-		$settings_needs_sync = $this->get_settings_needs_sync();
+	/**
+	 * Push settings to the Algolia
+	 *
+	 * @param  array $overrides The settings array that will be forcefully pushed.
+	 * @return bool
+	 */
+	public function push( $overrides = [] ): bool {
+		$settings = wp_parse_args( $overrides, $this->get_settings_needs_sync() );
 
-		if ( count( $settings_needs_sync ) === 0 ) {
+		if ( count( $settings ) === 0 ) {
 			return false;
 		}
 
 		try {
-			$this->get_algolia_index()->setSettings( $settings_needs_sync );
+			$this->get_algolia_index()->setSettings( $settings );
 		} catch ( Exception $e ) {
 			return false;
 		}

--- a/includes/indices/settings/class-algolia-primary-index-settings.php
+++ b/includes/indices/settings/class-algolia-primary-index-settings.php
@@ -4,9 +4,11 @@ use WebDevStudios\WPSWA\Algolia\AlgoliaSearch\SearchIndex;
 
 class Algolia_Primary_Index_Settings implements Algolia_Index_Settings {
 	protected Algolia_Index $index;
+	protected SearchIndex $algolia_index;
 
 	public function __construct( Algolia_Index $index ) {
 		$this->index = $index;
+		$this->set_algolia_index();
 	}
 
 	public function get_index(): Algolia_Index {
@@ -14,7 +16,11 @@ class Algolia_Primary_Index_Settings implements Algolia_Index_Settings {
 	}
 
 	public function get_algolia_index(): SearchIndex {
-		return $this->get_index()->get_index();
+		return $this->algolia_index;
+	}
+
+	public function set_algolia_index(): void {
+		$this->algolia_index = $this->get_index()->get_index();
 	}
 
 	public function get_local_settings(): array {

--- a/includes/indices/settings/class-algolia-replica-index-settings.php
+++ b/includes/indices/settings/class-algolia-replica-index-settings.php
@@ -1,0 +1,29 @@
+<?php
+
+class Algolia_Replica_Index_Settings extends Algolia_Index_Settings_Decorator {
+	protected Algolia_Index_Replica $replica;
+
+	public function __construct( Algolia_Index_Settings $index_settings, $replica ) {
+		parent::__construct( $index_settings );
+		$this->replica = $replica;
+	}
+
+	public function get_local_settings(): array {
+		$settings            = $this->index_settings->get_local_settings();
+		$settings['ranking'] = $this->replica->get_ranking();
+
+		return $settings;
+	}
+
+	protected function switch_algolia_index(): void {
+		$primary_index      = $this->index_settings->get_index();
+		$client             = $primary_index->get_client();
+		$replica_index_name = $this->replica->get_replica_index_name( $primary_index );
+		$this->set_algolia_index( $client->initIndex( $replica_index_name ) );
+	}
+
+	public function push(): bool {
+		$this->switch_algolia_index();
+		return parent::push();
+	}
+}

--- a/includes/indices/settings/interface-algolia-index-settings.php
+++ b/includes/indices/settings/interface-algolia-index-settings.php
@@ -1,0 +1,9 @@
+<?php
+
+interface Algolia_Index_Settings {
+	public function set_index( Algolia_Index $index);
+	public function get_index(): Algolia_Index;
+	public function get_local_settings(): array;
+	public function get_settings_needs_sync();
+	public function push(): bool;
+}

--- a/includes/indices/settings/interface-algolia-index-settings.php
+++ b/includes/indices/settings/interface-algolia-index-settings.php
@@ -1,9 +1,13 @@
 <?php
 
+use WebDevStudios\WPSWA\Algolia\AlgoliaSearch\SearchIndex;
+
 interface Algolia_Index_Settings {
 	public function get_index(): Algolia_Index;
 	public function get_local_settings(): array;
 	public function get_remote_settings(): array;
+	public function set_algolia_index(): void;
+	public function get_algolia_index(): SearchIndex;
 	public function get_settings_needs_sync(): array;
 	public function push(): bool;
 }

--- a/includes/indices/settings/interface-algolia-index-settings.php
+++ b/includes/indices/settings/interface-algolia-index-settings.php
@@ -4,6 +4,7 @@ interface Algolia_Index_Settings {
 	public function set_index( Algolia_Index $index);
 	public function get_index(): Algolia_Index;
 	public function get_local_settings(): array;
-	public function get_settings_needs_sync();
+	public function get_remote_settings(): array;
+	public function get_settings_needs_sync(): array;
 	public function push(): bool;
 }

--- a/includes/indices/settings/interface-algolia-index-settings.php
+++ b/includes/indices/settings/interface-algolia-index-settings.php
@@ -1,7 +1,6 @@
 <?php
 
 interface Algolia_Index_Settings {
-	public function set_index( Algolia_Index $index);
 	public function get_index(): Algolia_Index;
 	public function get_local_settings(): array;
 	public function get_remote_settings(): array;


### PR DESCRIPTION
The PR aims prevents overriding remote Algolia Index Settings.

**Key features**
* Only push a setting if the remote value is null or does not exists.
* [to be implemented] Forcefully push a setting ability. If a setting key is defined as should be pushed forcefully override it even though it's exists and not null.
* Reduce redundant code in Algolia_Index::get_settings methods

PR description will be updated when the PR is ready for the review.

Closes #317