### PR TITLE
[Feature-327] Wait for delete operations to complete before updates

### DIFF
--- a/includes/indices/class-algolia-posts-index.php
+++ b/includes/indices/class-algolia-posts-index.php
@@ -390,7 +390,7 @@ final class Algolia_Posts_Index extends Algolia_Index {
 		// If there are no records, parent `update_records` will take care of the deletion.
 		// In case of posts, we ALWAYS need to delete existing records.
 		if ( ! empty( $records ) ) {
-			$this->delete_item( $post );
+			$this->delete_item( $post, true );
 		}
 
 		parent::update_records( $post, $records );
@@ -469,8 +469,9 @@ final class Algolia_Posts_Index extends Algolia_Index {
 	 * @since  1.0.0
 	 *
 	 * @param mixed $item The item to delete.
+	 * @param bool  $wait Wait the for operation to complete.
 	 */
-	public function delete_item( $item ) {
+	public function delete_item( $item, $wait = false ) {
 		$this->assert_is_supported( $item );
 
 		$records_count = $this->get_post_records_count( $item->ID );
@@ -480,7 +481,7 @@ final class Algolia_Posts_Index extends Algolia_Index {
 		}
 
 		if ( ! empty( $object_ids ) ) {
-			$this->get_index()->deleteObjects( $object_ids );
+			$wait ? $this->get_index()->deleteObjects( $object_ids )->wait() : $this->get_index()->deleteObjects( $object_ids );
 		}
 	}
 

--- a/includes/indices/class-algolia-posts-index.php
+++ b/includes/indices/class-algolia-posts-index.php
@@ -480,9 +480,16 @@ final class Algolia_Posts_Index extends Algolia_Index {
 			$object_ids[] = $this->get_post_object_id( $item->ID, $i );
 		}
 
-		if ( ! empty( $object_ids ) ) {
-			$wait ? $this->get_index()->deleteObjects( $object_ids )->wait() : $this->get_index()->deleteObjects( $object_ids );
+		if ( empty( $object_ids ) ) {
+			return;
 		}
+		
+		if ( $wait ) {
+			$this->get_index()->deleteObjects( $object_ids )->wait();
+			return;
+		}
+		
+		$this->get_index()->deleteObjects( $object_ids );
 	}
 
 	/**

--- a/includes/indices/class-algolia-posts-index.php
+++ b/includes/indices/class-algolia-posts-index.php
@@ -469,7 +469,7 @@ final class Algolia_Posts_Index extends Algolia_Index {
 	 * @since  1.0.0
 	 *
 	 * @param mixed $item The item to delete.
-	 * @param bool  $wait Wait the for operation to complete.
+	 * @param bool  $wait Wait for the operation to complete synchronously.
 	 */
 	public function delete_item( $item, $wait = false ) {
 		$this->assert_is_supported( $item );

--- a/includes/indices/class-algolia-searchable-posts-index.php
+++ b/includes/indices/class-algolia-searchable-posts-index.php
@@ -467,9 +467,16 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index {
 			$object_ids[] = $this->get_post_object_id( $item->ID, $i );
 		}
 
-		if ( ! empty( $object_ids ) ) {
-			$wait ? $this->get_index()->deleteObjects( $object_ids )->wait() : $this->get_index()->deleteObjects( $object_ids );
+		if ( empty( $object_ids ) ) {
+			return;
 		}
+		
+		if ( $wait ) {
+			$this->get_index()->deleteObjects( $object_ids )->wait();
+			return;
+		}
+		
+		$this->get_index()->deleteObjects( $object_ids );
 	}
 
 	/**

--- a/includes/indices/class-algolia-searchable-posts-index.php
+++ b/includes/indices/class-algolia-searchable-posts-index.php
@@ -371,7 +371,7 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index {
 		// If there are no records, parent `update_records` will take care of the deletion.
 		// In case of posts, we ALWAYS need to delete existing records.
 		if ( ! empty( $records ) ) {
-			$this->delete_item( $post );
+			$this->delete_item( $post, true );
 		}
 
 		parent::update_records( $post, $records );

--- a/includes/indices/class-algolia-searchable-posts-index.php
+++ b/includes/indices/class-algolia-searchable-posts-index.php
@@ -456,8 +456,9 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index {
 	 * @since  1.0.0
 	 *
 	 * @param mixed $item The item to delete.
+	 * @param bool  $wait Wait the for operation to complete.
 	 */
-	public function delete_item( $item ) {
+	public function delete_item( $item, $wait = false ) {
 		$this->assert_is_supported( $item );
 
 		$records_count = $this->get_post_records_count( $item->ID );
@@ -467,7 +468,7 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index {
 		}
 
 		if ( ! empty( $object_ids ) ) {
-			$this->get_index()->deleteObjects( $object_ids );
+			$wait ? $this->get_index()->deleteObjects( $object_ids )->wait() : $this->get_index()->deleteObjects( $object_ids );
 		}
 	}
 

--- a/includes/indices/class-algolia-searchable-posts-index.php
+++ b/includes/indices/class-algolia-searchable-posts-index.php
@@ -456,7 +456,7 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index {
 	 * @since  1.0.0
 	 *
 	 * @param mixed $item The item to delete.
-	 * @param bool  $wait Wait the for operation to complete.
+	 * @param bool  $wait Wait for the operation to complete synchronously.
 	 */
 	public function delete_item( $item, $wait = false ) {
 		$this->assert_is_supported( $item );


### PR DESCRIPTION
Closes: #327 

Make the delete operation synchronous when executed in the context of an update request.