### PR TITLE
ensure reindexing completes when using the from_batch flag

### DIFF
--- a/includes/class-algolia-cli.php
+++ b/includes/class-algolia-cli.php
@@ -147,7 +147,7 @@ class Algolia_CLI {
 			$index->re_index( $page++ );
 			WP_CLI::log( sprintf( 'Indexed batch %s.', ( $page - 1 ) ) );
 			$progress->tick();
-		} while ( $page <= $total_pages );
+		} while ( $page <= ( $total_pages + $from_batch - 1 ) );
 
 		$progress->finish();
 


### PR DESCRIPTION
The value of ``$from_batch`` is correctly subtracted from $total_pages in line 128 of this includes/class-algolia-cli.php, but because the value of ``$page`` is set to the value of ``$from_batch`` on line 144, the value needs to be added back in the while loop condition. Otherwise, reindexing will fail to complete when using the flag. 