### PR TITLE
Fix usernames generating a 404 when ctrl/cmd/shift clicking them

### DIFF
--- a/includes/admin/partials/form-options.php
+++ b/includes/admin/partials/form-options.php
@@ -20,7 +20,7 @@
 			submit_button();
 			?>
 		</form>
-	<?php else: ?>
+	<?php else : ?>
 		<?php do_action( 'wpswa_pro_override_settings_output' ); ?>
 	<?php endif; ?>
 </div>

--- a/templates/autocomplete.php
+++ b/templates/autocomplete.php
@@ -173,7 +173,7 @@
 			var autocomplete = algoliaAutocomplete( element, config, sources )
 				.on( 'autocomplete:selected', function ( e, suggestion ) {
 					/* Redirect the user when we detect a suggestion selection. */
-					window.location.href = suggestion.permalink;
+					window.location.href = suggestion.permalink ?? suggestion.posts_url; // Users use the `posts_url` property instead of `permalink`.
 				} );
 
 			/* Force the dropdown to be re-drawn on scroll to handle fixed containers. */

--- a/templates/autocomplete.php
+++ b/templates/autocomplete.php
@@ -5,7 +5,7 @@
  * @author  WebDevStudios <contact@webdevstudios.com>
  * @since   1.0.0
  *
- * @version 2.5.0
+ * @version 2.5.3
  * @package WebDevStudios\WPSWA
  */
 


### PR DESCRIPTION
Fixes #292 

The user suggestion object uses the `posts_url` property for the link value instead of `permalink` like the other objects. This PR fixes the 404 error when ctrl/cmd/shift clicking user suggestions.