### PR TITLE
Watch for post slug changes before saving them

### DIFF
--- a/includes/watchers/class-algolia-post-changes-watcher.php
+++ b/includes/watchers/class-algolia-post-changes-watcher.php
@@ -91,7 +91,7 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 			return;
 		}
 
-		if ( in_array($post_id, $this->posts_deleted, true ) ) {
+		if ( in_array( $post_id, $this->posts_deleted, true ) ) {
 			return;
 		}
 

--- a/includes/watchers/class-algolia-post-changes-watcher.php
+++ b/includes/watchers/class-algolia-post-changes-watcher.php
@@ -91,7 +91,7 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 			return;
 		}
 
-		if ( in_array( $post_id, $this->posts_deleted, true ) ) {
+		if ( in_array($post_id, $this->posts_deleted, true ) ) {
 			return;
 		}
 
@@ -117,30 +117,29 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 
 	/**
 	 * Check if a slug has been changed and add the childrens into a transient ( if it has children ).
-	 * 
+	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
 	 *
 	 * @since 2.5.3
-	 * @param int $post_id The parent ID.
-	 *
+	 * @param int   $post_id The parent ID.
+	 * @param array $post_data An array containing the new post data.
 	 * @return void
-	 * 
 	 */
 	public function check_slug_update( $post_id, $post_data ) {
 		$post = get_post( (int) $post_id );
 		if ( isset( $post_data['post_name'] ) && $post_data['post_name'] !== $post->post_name ) {
-			
+
 			$child_posts = get_children( [
 				'post_parent' => $post_id,
 			] );
 
-			$pending_childs = array();
-			foreach( $child_posts as $child_post ) {
-				if ( $child_post->post_status !== 'inherit' ) {
+			$pending_childs = [];
+			foreach ( $child_posts as $child_post ) {
+				if ( 'inherit' !== $child_post->post_status ) {
 					$pending_childs[] = $child_post;
 				}
 			}
-			set_transient( 'wp_algolia_child_posts_'. $post_id, $pending_childs, 60 );
+			set_transient( 'wp_algolia_child_posts_' . $post_id, $pending_childs, 60 );
 		}
 
 	}


### PR DESCRIPTION
This watches for slug changes on posts that have children posts. If a child post is found on this condition, it's saved inside a transient to be synced after the post is updated.
