### PR TITLE
Feature/236 instantsearch templates

### DIFF
--- a/includes/class-algolia-scripts.php
+++ b/includes/class-algolia-scripts.php
@@ -78,8 +78,6 @@ class Algolia_Scripts {
 			'algolia-instantsearch',
 			ALGOLIA_PLUGIN_URL . 'js/instantsearch.js/dist/instantsearch' . $ais_suffix . $suffix . '.js',
 			[
-				'underscore',
-				'wp-util',
 				'algolia-search',
 			],
 			ALGOLIA_VERSION,

--- a/templates/instantsearch.php
+++ b/templates/instantsearch.php
@@ -128,6 +128,7 @@ get_header();
 												<p>${content_snippet}</p>
 											</div>
 										</div>
+										<div class="ais-clearfix"></div>
 									</article>`;
 							}
 						},

--- a/templates/instantsearch.php
+++ b/templates/instantsearch.php
@@ -44,34 +44,6 @@ get_header();
 		</aside>
 	</div>
 
-	<script type="text/html" id="tmpl-instantsearch-hit">
-		<article itemtype="http://schema.org/Article">
-			<# if ( data.images.thumbnail ) { #>
-				<div class="ais-hits--thumbnail">
-					<a href="{{ data.permalink }}" title="{{ data.post_title }}" class="ais-hits--thumbnail-link">
-						<img src="{{ data.images.thumbnail.url }}" alt="{{ data.post_title }}" title="{{ data.post_title }}" itemprop="image" />
-					</a>
-				</div>
-			<# } #>
-
-			<div class="ais-hits--content">
-				<h2 itemprop="name headline"><a href="{{ data.permalink }}" title="{{ data.post_title }}" class="ais-hits--title-link" itemprop="url">{{{ data._highlightResult.post_title.value }}}</a></h2>
-				<div class="excerpt">
-					<p>
-						<# if ( data._snippetResult['content'] ) { #>
-							<span class="suggestion-post-content ais-hits--content-snippet">{{{ data._snippetResult['content'].value }}}</span>
-						<# } #>
-					</p>
-				</div>
-				<?php
-				do_action( 'algolia_instantsearch_after_hit' );
-				?>
-			</div>
-			<div class="ais-clearfix"></div>
-		</article>
-	</script>
-
-
 	<script type="text/javascript">
 		window.addEventListener('load', function() {
 			if ( document.getElementById("algolia-search-box") ) {

--- a/templates/instantsearch.php
+++ b/templates/instantsearch.php
@@ -54,7 +54,7 @@ get_header();
 				}
 
 				/* Instantiate instantsearch.js */
-				var search = instantsearch({
+				const search = instantsearch({
 					indexName: algolia.indices.searchable_posts.name,
 					searchClient: algoliasearch( algolia.application_id, algolia.search_api_key ),
 					routing: {

--- a/templates/instantsearch.php
+++ b/templates/instantsearch.php
@@ -78,7 +78,8 @@ get_header();
 
 				search.addWidgets([
 
-					/* Search box widget */
+					// Search box widget
+					// https://www.algolia.com/doc/api-reference/widgets/search-box/js/
 					instantsearch.widgets.searchBox({
 						container: '#algolia-search-box',
 						placeholder: 'Search for...',
@@ -87,16 +88,20 @@ get_header();
 						showLoadingIndicator: false,
 					}),
 
-					/* Stats widget */
+					// Stats widget
+					// https://www.algolia.com/doc/api-reference/widgets/stats/js/
 					instantsearch.widgets.stats({
 						container: '#algolia-stats'
 					}),
 
+					// Configure widget
+					// https://www.algolia.com/doc/api-reference/widgets/configure/js/
 					instantsearch.widgets.configure({
 						hitsPerPage: 10,
 					}),
 
-					/* Hits widget */
+					// Hits widget
+					// https://www.algolia.com/doc/api-reference/widgets/hits/js/
 					instantsearch.widgets.hits({
 						container: '#algolia-hits',
 						templates: {
@@ -155,12 +160,14 @@ get_header();
 						}
 					}),
 
-					/* Pagination widget */
+					// Pagination widget
+					// https://www.algolia.com/doc/api-reference/widgets/pagination/js/
 					instantsearch.widgets.pagination({
 						container: '#algolia-pagination'
 					}),
 
-					/* Post types refinement widget */
+					// Post types refinement widget
+					// https://www.algolia.com/doc/api-reference/widgets/menu/js/
 					instantsearch.widgets.menu({
 						container: '#facet-post-types',
 						attribute: 'post_type_label',
@@ -168,7 +175,8 @@ get_header();
 						limit: 10,
 					}),
 
-					/* Categories refinement widget */
+					// Categories refinement widget
+					// https://www.algolia.com/doc/api-reference/widgets/hierarchical-menu/js/
 					instantsearch.widgets.hierarchicalMenu({
 						container: '#facet-categories',
 						separator: ' > ',
@@ -176,7 +184,8 @@ get_header();
 						attributes: ['taxonomies_hierarchical.category.lvl0', 'taxonomies_hierarchical.category.lvl1', 'taxonomies_hierarchical.category.lvl2'],
 					}),
 
-					/* Tags refinement widget */
+					// Tags refinement widget
+					// https://www.algolia.com/doc/api-reference/widgets/refinement-list/js/
 					instantsearch.widgets.refinementList({
 						container: '#facet-tags',
 						attribute: 'taxonomies.post_tag',
@@ -185,13 +194,20 @@ get_header();
 						sortBy: ['isRefined:desc', 'count:desc', 'name:asc'],
 					}),
 
-					/* Users refinement widget */
+					// Users refinement widget
+					// https://www.algolia.com/doc/api-reference/widgets/menu/js/
 					instantsearch.widgets.menu({
 						container: '#facet-users',
 						attribute: 'post_author.display_name',
 						sortBy: ['isRefined:desc', 'count:desc', 'name:asc'],
 						limit: 10,
 					}),
+
+					// Search powered-by widget
+					// https://www.algolia.com/doc/api-reference/widgets/powered-by/js/
+					instantsearch.widgets.poweredBy({
+						container: '#algolia-powered-by'
+					})
 				]);
 
 				if ( algolia.powered_by_enabled ) {

--- a/templates/instantsearch.php
+++ b/templates/instantsearch.php
@@ -49,8 +49,8 @@ get_header();
 			// Set a custom user token if you enable insights and don't want the anonymous token.
 			// window.aa('setUserToken', 'some-user-id');
 			if ( document.getElementById("algolia-search-box") ) {
-				if ( algolia.indices.searchable_posts === undefined && document.getElementsByClassName("admin-bar").length > 0) {
-					alert('It looks like you haven\'t indexed the searchable posts index. Please head to the Indexing page of the Algolia Search plugin and index it.');
+				if ( algolia.indices.searchable_posts === undefined && document.getElementsByClassName("admin-bar").length > 0 ) {
+					alert('<?php esc_html_e( "It looks like you have not indexed the searchable posts index. Please head to the Indexing page of the Algolia Search plugin and index it.", 'wp-search-with-algolia' ); ?>');
 				}
 
 				/* Instantiate instantsearch.js */

--- a/templates/instantsearch.php
+++ b/templates/instantsearch.php
@@ -5,7 +5,7 @@
  * @author  WebDevStudios <contact@webdevstudios.com>
  * @since   1.0.0
  *
- * @version NEXT
+ * @version 2.9.0
  * @package WebDevStudios\WPSWA
  */
 

--- a/templates/instantsearch.php
+++ b/templates/instantsearch.php
@@ -135,7 +135,7 @@ get_header();
 									content_snippet = html`<span class="suggestion-post-content ais-hits--content-snippet">${components.Snippet({hit, attribute: 'content'})}</span>`;
 								}
 
-								var extras = '';
+								let extras = '';
 
 								<?php
 								do_action( 'algolia_instantsearch_after_hit' );
@@ -163,7 +163,7 @@ get_header();
 										item.value = _.escape(item.value);
 										item.value = item.value.replace(/__ais-highlight__/g, '<em>').replace(/__\/ais-highlight__/g, '</em>');
 									} else {
-										for (var key in item) {
+										for (let key in item) {
 											item[key] = replace_highlights_recursive(item[key]);
 										}
 									}

--- a/templates/instantsearch.php
+++ b/templates/instantsearch.php
@@ -124,6 +124,12 @@ get_header();
 									content_snippet = html`<span class="suggestion-post-content ais-hits--content-snippet">${components.Snippet({hit, attribute: 'content'})}</span>`;
 								}
 
+								var extras = '';
+
+								<?php
+								do_action( 'algolia_instantsearch_after_hit' );
+								?>
+
 								return html`
 									<article itemtype="http://schema.org/Article">
 										${thumbnail}
@@ -134,6 +140,7 @@ get_header();
 											</div>
 										</div>
 										<div class="ais-clearfix"></div>
+										${extras}
 									</article>`;
 							}
 						},

--- a/templates/instantsearch.php
+++ b/templates/instantsearch.php
@@ -46,6 +46,8 @@ get_header();
 
 	<script type="text/javascript">
 		window.addEventListener('load', function() {
+			// Set a custom user token if you enable insights and don't want the anonymous token.
+			// window.aa('setUserToken', 'some-user-id');
 			if ( document.getElementById("algolia-search-box") ) {
 				if ( algolia.indices.searchable_posts === undefined && document.getElementsByClassName("admin-bar").length > 0) {
 					alert('It looks like you haven\'t indexed the searchable posts index. Please head to the Indexing page of the Algolia Search plugin and index it.');
@@ -74,6 +76,15 @@ get_header();
 							}
 						}
 					}
+					// https://www.algolia.com/doc/guides/building-search-ui/events/js/
+					//insights: true,
+					/*
+					insights: {
+						insightsInitParams: {
+							useCookie: true
+						}
+					},
+					 */
 				});
 
 				search.addWidgets([

--- a/templates/instantsearch.php
+++ b/templates/instantsearch.php
@@ -100,8 +100,36 @@ get_header();
 					instantsearch.widgets.hits({
 						container: '#algolia-hits',
 						templates: {
-							empty: 'No results were found for "<strong>{{query}}</strong>".',
-							item: wp.template('instantsearch-hit')
+							empty(results, {html} ) {
+								return html `No results were found for "<strong>${results.query}</strong>".`;
+							},
+							item(hit, { html, components }) {
+								let thumbnail = '';
+								if ( hit.images.thumbnail ) {
+									thumbnail = html`
+									<div class="ais-hits--thumbnail">
+										<a href="${hit.permalink}" title="${hit.post_title }" class="ais-hits--thumbnail-link">
+											<img src="${hit.images.thumbnail.url }" alt="${hit.post_title }" title="${hit.post_title }" itemprop="image" />
+										</a>
+									</div>`;
+								}
+
+								let content_snippet = '';
+								if (hit._snippetResult['content']) {
+									content_snippet = html`<span class="suggestion-post-content ais-hits--content-snippet">${components.Snippet({hit, attribute: 'content'})}</span>`;
+								}
+
+								return html`
+									<article itemtype="http://schema.org/Article">
+										${thumbnail}
+										<div class="ais-hits--content">
+											<h2 itemprop="name headline"><a href="${hit.permalink}" title="${hit.post_title}" class="ais-hits--title-link" itemprop="url">${components.Highlight({hit, attribute: 'post_title'})}</a></h2>
+											<div class="excerpt">
+												<p>${content_snippet}</p>
+											</div>
+										</div>
+									</article>`;
+							}
 						},
 						transformData: {
 							item: function (hit) {

--- a/templates/instantsearch.php
+++ b/templates/instantsearch.php
@@ -5,7 +5,7 @@
  * @author  WebDevStudios <contact@webdevstudios.com>
  * @since   1.0.0
  *
- * @version 2.7.1
+ * @version NEXT
  * @package WebDevStudios\WPSWA
  */
 


### PR DESCRIPTION
I'm feeling like this is going to be a minimal impact overall, as anyone still using the fallback, will likely see zero change with this, and anyone that has customized, is hopefully using this `html` template tagging method already.

That said, we will definitely still want to let it be known in the changelog that we'd be removing the dependencies with `underscores` and `wp-util`, so that they know they may need to re-enqueue