### PR TITLE
Prevent table content from being concatenated

### DIFF
--- a/includes/class-algolia-utils.php
+++ b/includes/class-algolia-utils.php
@@ -154,7 +154,7 @@ class Algolia_Utils {
 		$content = self::remove_content_noise( $content );
 
 		// Prevent table content from being concatenated.
-		$content = str_replace( array( '<td>', '<th>' ), ' ', $content );
+		$content = str_replace( array( '</td>', '</th>' ), ' ', $content );
 
 		return wp_strip_all_tags( $content );
 	}

--- a/includes/class-algolia-utils.php
+++ b/includes/class-algolia-utils.php
@@ -153,9 +153,6 @@ class Algolia_Utils {
 	public static function prepare_content( $content ) {
 		$content = self::remove_content_noise( $content );
 
-		// Prevent table content from being concatenated.
-		$content = str_replace( array( '</td>', '</th>' ), ' ', $content );
-
 		return wp_strip_all_tags( $content );
 	}
 
@@ -202,6 +199,9 @@ class Algolia_Utils {
 		}
 
 		$content = str_replace( '&nbsp;', ' ', $content );
+
+		// Prevent table content from being concatenated.
+		$content = str_replace( array( '</td>', '</th>' ), ' ', $content );
 
 		return html_entity_decode( $content );
 	}

--- a/includes/class-algolia-utils.php
+++ b/includes/class-algolia-utils.php
@@ -153,6 +153,9 @@ class Algolia_Utils {
 	public static function prepare_content( $content ) {
 		$content = self::remove_content_noise( $content );
 
+		// Prevent table content from being concatenated.
+		$content = str_replace( array( '<td>', '<th>' ), ' ', $content );
+
 		return wp_strip_all_tags( $content );
 	}
 


### PR DESCRIPTION
This PR prevents the contents of table blocks from being concatenated by making them unsearchable. A space is added after the cell tags so that they remain independent words after applying `wp_strip_all_tags`.

Before
![CleanShot 2024-02-20 at 15 49 55](https://github.com/WebDevStudios/wp-search-with-algolia/assets/11416255/bdc932db-8314-4df0-bfc8-1d150c9be308)

After
![CleanShot 2024-02-20 at 15 50 43](https://github.com/WebDevStudios/wp-search-with-algolia/assets/11416255/c9847304-8b95-4628-81a2-cac235ac0794)