### PR TITLE
Release 2.8.1

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Tags: search, algolia, autocomplete, instantsearch, relevance search, faceted se
 Requires at least: 5.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 2.8.0
+Stable tag: 2.8.1
 License: GNU General Public License v2.0, MIT License
 
 Use the power of Algolia to enhance your website's search. Enable Autocomplete and Instantsearch for fast and accurate results and relevance.
@@ -127,6 +127,9 @@ All development is handled on [GitHub](https://github.com/WebDevStudios/wp-searc
 == Changelog ==
 
 Follow along with the changelog on [Github](https://github.com/WebDevStudios/wp-search-with-algolia/releases).
+
+= 2.8.1 =
+* Updated: WP Search with Algolia Pro features list for version 1.4.0
 
 = 2.8.0 =
 * Added: Filter to customize Algolia SearchClient configuration with connect/read/write timeouts.

--- a/algolia.php
+++ b/algolia.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WP Search with Algolia
  * Plugin URI:        https://github.com/WebDevStudios/wp-search-with-algolia
  * Description:       Integrate the powerful Algolia search service with WordPress
- * Version:           2.8.0
+ * Version:           2.8.1
  * Requires at least: 5.0
  * Requires PHP:      7.4
  * Author:            WebDevStudios
@@ -26,7 +26,7 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 // The Algolia Search plugin version.
-define( 'ALGOLIA_VERSION', '2.8.0' );
+define( 'ALGOLIA_VERSION', '2.8.1' );
 
 // The minmum required PHP version.
 define( 'ALGOLIA_MIN_PHP_VERSION', '7.4' );

--- a/includes/class-algolia-utils.php
+++ b/includes/class-algolia-utils.php
@@ -299,38 +299,47 @@ class Algolia_Utils {
 			</h3>
 			<div class="algolia-pro-features">
 				<div>
+					<?php $svg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#0077ff" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>'; ?>
 					<h4><?php esc_html_e( 'WooCommerce Support', 'wp-search-with-algolia' ); ?></h4>
 					<span class="algolia-pro-feature">
-						<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#0077ff" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
-						<span><?php esc_html_e( 'Index product SKUs, prices and short descriptions for display.', 'wp-search-with-algolia' ); ?></span>
+						<?php echo $svg; ?>
+						<span><?php esc_html_e( 'Index product SKUs, prices, short descriptions and product dimensions/weight for display.', 'wp-search-with-algolia' ); ?></span>
 					</span>
 					<span class="algolia-pro-feature">
-						<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#0077ff" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+						<?php echo $svg; ?>
 						<span><?php esc_html_e( 'Index product total sales ratings for relevance.', 'wp-search-with-algolia' ); ?></span>
 					</span>
 					<span class="algolia-pro-feature">
-						<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#0077ff" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+						<?php echo $svg; ?>
 						<span><?php esc_html_e( 'Index product total and average ratings for relevance.', 'wp-search-with-algolia' ); ?></span>
 					</span>
 					<span class="algolia-pro-feature">
-						<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#0077ff" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+						<?php echo $svg; ?>
+						<span><?php esc_html_e( 'Control whether or not sold out products are indexed', 'wp-search-with-algolia' ); ?></span>
+					</span>
+					<span class="algolia-pro-feature">
+						<?php echo $svg; ?>
+						<span><?php esc_html_e( 'Control whether or not "shop only" or "hidden" products are indexed.', 'wp-search-with-algolia' ); ?></span>
+					</span>
+					<span class="algolia-pro-feature">
+						<?php echo $svg; ?>
 						<span><?php esc_html_e( 'Amend indexing to only include WooCommerce products.', 'wp-search-with-algolia' ); ?></span>
 					</span>
 				</div>
 				<div>
 					<h4><?php esc_html_e( 'Additional Features', 'wp-search-with-algolia' ); ?></h4>
 					<span class="algolia-pro-feature">
-					<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#0077ff" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
-					<span><?php esc_html_e( 'Multisite indexing into a single network index to provide a global Algolia-powered search experience.', 'wp-search-with-algolia' ); ?></span>
-				</span>
+						<?php echo $svg; ?>
+						<span><?php esc_html_e( 'Multisite indexing into a single network index to provide a global Algolia-powered search experience.', 'wp-search-with-algolia' ); ?></span>
+					</span>
 					<span class="algolia-pro-feature">
-					<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#0077ff" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
-					<span><?php esc_html_e( 'Fine tune indexing on selected pieces of content', 'wp-search-with-algolia' ); ?></span>
-				</span>
+						<?php echo $svg; ?>
+						<span><?php esc_html_e( 'Fine tune indexing on selected pieces of content', 'wp-search-with-algolia' ); ?></span>
+					</span>
 					<span class="algolia-pro-feature">
-					<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#0077ff" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
-					<span><?php esc_html_e( 'Yoast SEO, All in One SEO, Rank Math SEO, and SEOPress Support', 'wp-search-with-algolia' ); ?></span>
-				</span>
+						<?php echo $svg; ?>
+						<span><?php esc_html_e( 'Yoast SEO, All in One SEO, Rank Math SEO, SEOPress, and The SEO Framework Support', 'wp-search-with-algolia' ); ?></span>
+					</span>
 				</div>
 			</div>
 			<div>

--- a/includes/factories/class-algolia-search-client-factory.php
+++ b/includes/factories/class-algolia-search-client-factory.php
@@ -61,7 +61,7 @@ class Algolia_Search_Client_Factory {
 		 * Allows for providing custom configuration arguments for Algolia Search Client.
 		 *
 		 * @see https://www.algolia.com/doc/api-reference/api-methods/configuring-timeouts/
-		 * @since NEXT
+		 * @since 2.8.0
 		 *
 		 * @param array $value Array of values for Algolia Config. Default empty array.
 		 */


### PR DESCRIPTION
This PR primarily updates and slightly reworks how we use SVG files in a popup that we have that highlights WP Search with Algolia Pro features, after the release of Pro 1.4.0.

It also fixes a missed @ since version tag.