### PR TITLE
Feature/wpce 330 algolia autocomplete debounce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+## NEXT
+
+* Added an option to set the debounce timeout value which applies to all indexes by default, but can be customized for
+  each index with a filter:
+
+Dynamic filter name: `algolia_autocomplete_debounce_{$index_name}_{$index_type}`
+
+Where `$index_name` is defined by the Index name prefix set on the WP Search with Algolia settings page and
+`$index_type` is the type of index.
+
+Assuming `wp_` is the Index name prefix, the debounce timeout filters would be:
+
+```
+algolia_autocomplete_debounce_wp_searchable_posts
+algolia_autocomplete_debounce_wp_post
+algolia_autocomplete_debounce_wp_page
+algolia_autocomplete_debounce_wp_my_custom_post_type
+algolia_autocomplete_debounce_wp_users
+algolia_autocomplete_debounce_wp_terms_category
+algolia_autocomplete_debounce_wp_terms_post_tag
+algolia_autocomplete_debounce_wp_terms_my_custom_taxonomy
+```
+
+Note that the Algolia Autocomplete settings must be saved after creating one of the above filters.
+
 ## 2.8.3
 * Fixed: "Function _load_textdomain_just_in_time was called incorrectly" notices.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 2.10.0
 
 * Added an option to set the debounce timeout value which applies to all indexes by default, but can be customized for
   each index with a filter:
@@ -22,6 +22,15 @@ algolia_autocomplete_debounce_wp_terms_my_custom_taxonomy
 ```
 
 Note that the Algolia Autocomplete settings must be saved after creating one of the above filters.
+
+## 2.9.0
+
+* Added: Instantsearch Template options. Choose between “Legacy” hogan.js/WP Utils templates and “Modern” Javascript string literals. “Modern” is more in line with Algolia Documentation.
+* Added: ability to customize default Headers for Algolia Search Client configuration.
+* Added: Initial support for programmatic Secured API key creation.
+* Updated: Sync’d up get_items() methods to allow for specifying specific IDs for posts, terms, and users.
+* Updated: Instantsearch templates use “Posts per page” amount by default, from WordPress Reading settings.
+* Updated: Amended Autocomplete settings page to remove more builtin post types that don’t need to be available.
 
 ## 2.8.3
 * Fixed: "Function _load_textdomain_just_in_time was called incorrectly" notices.

--- a/README.txt
+++ b/README.txt
@@ -1,5 +1,5 @@
 === WP Search with Algolia ===
-Contributors: WebDevStudios, williamsba1, tw2113, mrasharirfan, scottbasgaard, gregrickaby, richaber
+Contributors: WebDevStudios, williamsba1, tw2113, mrasharirfan, scottbasgaard, gregrickaby, richaber, daveromsey
 Tags: search, algolia, autocomplete, instantsearch, relevance search, faceted search, find-as-you-type search, ecommerce, seo, woocommerce, advanced search
 Requires at least: 5.3
 Tested up to: 6.8.1

--- a/includes/admin/class-algolia-admin-page-autocomplete.php
+++ b/includes/admin/class-algolia-admin-page-autocomplete.php
@@ -142,6 +142,14 @@ class Algolia_Admin_Page_Autocomplete {
 		);
 
 		add_settings_field(
+			'algolia_autocomplete_debounce',
+			esc_html__( 'Autocomplete Debounce', 'wp-search-with-algolia' ),
+			array( $this, 'autocomplete_debounce_callback' ),
+			$this->slug,
+			$this->section
+		);
+
+		add_settings_field(
 			'algolia_autocomplete_config',
 			esc_html__( 'Autocomplete Config', 'wp-search-with-algolia' ),
 			array( $this, 'autocomplete_config_callback' ),
@@ -150,6 +158,7 @@ class Algolia_Admin_Page_Autocomplete {
 		);
 
 		register_setting( $this->option_group, 'algolia_autocomplete_enabled', array( $this, 'sanitize_autocomplete_enabled' ) );
+		register_setting( $this->option_group, 'algolia_autocomplete_debounce', array( $this, 'sanitize_autocomplete_debounce' ) );
 		register_setting( $this->option_group, 'algolia_autocomplete_config', array( $this, 'sanitize_autocomplete_config' ) );
 	}
 
@@ -166,6 +175,25 @@ class Algolia_Admin_Page_Autocomplete {
 		$disabled = empty( $indices ) ? 'disabled ' : '';
 		?>
 		<input type='checkbox' name='algolia_autocomplete_enabled' value='yes' <?php echo esc_html( $checked . ' ' . $disabled ); ?>/>
+		<?php
+	}
+
+	/**
+	 * Callback to print the autocomplete debounce value.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since NEXT
+	 */
+	public function autocomplete_debounce_callback() {
+		$value    = $this->settings->get_autocomplete_debounce();
+		$indices  = $this->autocomplete_config->get_form_data();
+		$disabled = empty( $indices ) ? 'disabled ' : '';
+		?>
+		<input type="number" name="algolia_autocomplete_debounce" class="small-text" min="0" value="<?php echo esc_attr( $value ); ?>" <?php echo esc_html( $disabled ); ?>/>
+		<p class="description" id="home-description">
+			<?php esc_html_e( 'Enter the debounce timeout value in miliseconds. Use 0 (default) to disable debounce.', 'wp-search-with-algolia' ); ?>
+			<a href="https://www.algolia.com/doc/ui-libraries/autocomplete/guides/debouncing-sources/" target="_blank"><?php esc_html_e( 'Debouncing sources documentation', 'wp-search-with-algolia' ); ?></a>
+		</p>
 		<?php
 	}
 
@@ -189,6 +217,20 @@ class Algolia_Admin_Page_Autocomplete {
 		);
 
 		return 'yes' === $value ? 'yes' : 'no';
+	}
+
+	/**
+	 * Sanitize the Autocomplete debounce setting.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  NEXT
+	 *
+	 * @param int $value The original value.
+	 *
+	 * @return int The sanitized value.
+	 */
+	public function sanitize_autocomplete_debounce( $value ) {
+		return intval( $value );
 	}
 
 	/**

--- a/includes/admin/class-algolia-admin-page-autocomplete.php
+++ b/includes/admin/class-algolia-admin-page-autocomplete.php
@@ -182,7 +182,7 @@ class Algolia_Admin_Page_Autocomplete {
 	 * Callback to print the autocomplete debounce value.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since NEXT
+	 * @since 2.10.0
 	 */
 	public function autocomplete_debounce_callback() {
 		$value    = $this->settings->get_autocomplete_debounce();
@@ -223,7 +223,7 @@ class Algolia_Admin_Page_Autocomplete {
 	 * Sanitize the Autocomplete debounce setting.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  NEXT
+	 * @since  2.10.0
 	 *
 	 * @param int $value The original value.
 	 *

--- a/includes/admin/class-algolia-admin-page-autocomplete.php
+++ b/includes/admin/class-algolia-admin-page-autocomplete.php
@@ -187,9 +187,8 @@ class Algolia_Admin_Page_Autocomplete {
 	public function autocomplete_debounce_callback() {
 		$value    = $this->settings->get_autocomplete_debounce();
 		$indices  = $this->autocomplete_config->get_form_data();
-		$disabled = empty( $indices ) ? 'disabled ' : '';
 		?>
-		<input type="number" name="algolia_autocomplete_debounce" class="small-text" min="0" value="<?php echo esc_attr( $value ); ?>" <?php echo esc_html( $disabled ); ?>/>
+		<input type="number" name="algolia_autocomplete_debounce" class="small-text" min="0" value="<?php echo esc_attr( $value ); ?>" <?php disabled( empty( $indices ) ); ?>/>
 		<p class="description" id="home-description">
 			<?php esc_html_e( 'Enter the debounce timeout value in miliseconds. Use 0 (default) to disable debounce.', 'wp-search-with-algolia' ); ?>
 			<a href="https://www.algolia.com/doc/ui-libraries/autocomplete/guides/debouncing-sources/" target="_blank"><?php esc_html_e( 'Debouncing sources documentation', 'wp-search-with-algolia' ); ?></a>

--- a/includes/class-algolia-settings.php
+++ b/includes/class-algolia-settings.php
@@ -284,7 +284,7 @@ class Algolia_Settings {
 	 * 0 will disable the feature (default).
 	 *
 	 * @author  WebDevStudios <contact@webdevstudios.com>
-	 * @since   next
+	 * @since   2.10.0
 	 *
 	 * @return int Debounce value in milliseconds.
 	 */
@@ -294,7 +294,7 @@ class Algolia_Settings {
 		/**
 		 * Filters the autocomplete debounce option for algolia autocomplete.
 		 *
-		 * @since NEXT
+		 * @since 2.10.0
 		 *
 		 * @param int Debounce value in milliseconds.
 		 */

--- a/includes/class-algolia-settings.php
+++ b/includes/class-algolia-settings.php
@@ -27,6 +27,7 @@ class Algolia_Settings {
 		add_option( 'algolia_api_key', '' );
 		add_option( 'algolia_synced_indices_ids', array() );
 		add_option( 'algolia_autocomplete_enabled', 'no' );
+		add_option( 'algolia_autocomplete_debounce', 0 );
 		add_option( 'algolia_autocomplete_config', array() );
 		add_option( 'algolia_override_native_search', 'native' );
 		add_option( 'algolia_instantsearch_template_version', 'legacy' );
@@ -276,6 +277,28 @@ class Algolia_Settings {
 		 * @param string $enabled Can be 'yes' or 'no'.
 		 */
 		return apply_filters( 'algolia_should_override_autocomplete', $enabled );
+	}
+
+	/**
+	 * Get the autocomplete debounce timeout settings value in milliseconds.
+	 * 0 will disable the feature (default).
+	 *
+	 * @author  WebDevStudios <contact@webdevstudios.com>
+	 * @since   next
+	 *
+	 * @return int Debounce value in milliseconds.
+	 */
+	public function get_autocomplete_debounce() {
+		$debounce = (int) get_option( 'algolia_autocomplete_debounce', 0 );
+
+		/**
+		 * Filters the autocomplete debounce option for algolia autocomplete.
+		 *
+		 * @since NEXT
+		 *
+		 * @param int Debounce value in milliseconds.
+		 */
+		return (int) apply_filters( 'algolia_autocomplete_debounce', $debounce );
 	}
 
 	/**

--- a/includes/class-algolia-utils.php
+++ b/includes/class-algolia-utils.php
@@ -302,42 +302,42 @@ class Algolia_Utils {
 					<?php $svg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#0077ff" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>'; ?>
 					<h4><?php esc_html_e( 'WooCommerce Support', 'wp-search-with-algolia' ); ?></h4>
 					<span class="algolia-pro-feature">
-						<?php echo $svg; ?>
+						<?php echo $svg; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is a hardcoded SVG. ?>
 						<span><?php esc_html_e( 'Index product SKUs, prices, short descriptions and product dimensions/weight for display.', 'wp-search-with-algolia' ); ?></span>
 					</span>
 					<span class="algolia-pro-feature">
-						<?php echo $svg; ?>
+						<?php echo $svg; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is a hardcoded SVG. ?>
 						<span><?php esc_html_e( 'Index product total sales ratings for relevance.', 'wp-search-with-algolia' ); ?></span>
 					</span>
 					<span class="algolia-pro-feature">
-						<?php echo $svg; ?>
+						<?php echo $svg; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is a hardcoded SVG. ?>
 						<span><?php esc_html_e( 'Index product total and average ratings for relevance.', 'wp-search-with-algolia' ); ?></span>
 					</span>
 					<span class="algolia-pro-feature">
-						<?php echo $svg; ?>
+						<?php echo $svg; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is a hardcoded SVG. ?>
 						<span><?php esc_html_e( 'Control whether or not sold out products are indexed', 'wp-search-with-algolia' ); ?></span>
 					</span>
 					<span class="algolia-pro-feature">
-						<?php echo $svg; ?>
+						<?php echo $svg; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is a hardcoded SVG. ?>
 						<span><?php esc_html_e( 'Control whether or not "shop only" or "hidden" products are indexed.', 'wp-search-with-algolia' ); ?></span>
 					</span>
 					<span class="algolia-pro-feature">
-						<?php echo $svg; ?>
+						<?php echo $svg; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is a hardcoded SVG. ?>
 						<span><?php esc_html_e( 'Amend indexing to only include WooCommerce products.', 'wp-search-with-algolia' ); ?></span>
 					</span>
 				</div>
 				<div>
 					<h4><?php esc_html_e( 'Additional Features', 'wp-search-with-algolia' ); ?></h4>
 					<span class="algolia-pro-feature">
-						<?php echo $svg; ?>
+						<?php echo $svg; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is a hardcoded SVG. ?>
 						<span><?php esc_html_e( 'Multisite indexing into a single network index to provide a global Algolia-powered search experience.', 'wp-search-with-algolia' ); ?></span>
 					</span>
 					<span class="algolia-pro-feature">
-						<?php echo $svg; ?>
+						<?php echo $svg; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is a hardcoded SVG. ?>
 						<span><?php esc_html_e( 'Fine tune indexing on selected pieces of content', 'wp-search-with-algolia' ); ?></span>
 					</span>
 					<span class="algolia-pro-feature">
-						<?php echo $svg; ?>
+						<?php echo $svg; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- This is a hardcoded SVG. ?>
 						<span><?php esc_html_e( 'Yoast SEO, All in One SEO, Rank Math SEO, SEOPress, and The SEO Framework Support', 'wp-search-with-algolia' ); ?></span>
 					</span>
 				</div>

--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -730,9 +730,12 @@ abstract class Algolia_Index {
 	 * @author WebDevStudios <contact@webdevstudios.com>
 	 * @since  1.0.0
 	 *
-	 * @return array
+	 * @return array Autocomplete config.
 	 */
 	public function get_default_autocomplete_config() {
+		$plugin_settings = new \Algolia_Settings();
+		$debounce        = $plugin_settings->get_autocomplete_debounce();
+
 		return array(
 			'index_id'        => $this->get_id(),
 			'index_name'      => $this->get_name(),
@@ -740,6 +743,7 @@ abstract class Algolia_Index {
 			'admin_name'      => $this->get_admin_name(),
 			'position'        => 10,
 			'max_suggestions' => 5,
+			'debounce'        => $debounce,
 			'tmpl_suggestion' => 'autocomplete-post-suggestion',
 		);
 	}

--- a/includes/indices/class-algolia-posts-index.php
+++ b/includes/indices/class-algolia-posts-index.php
@@ -67,6 +67,37 @@ final class Algolia_Posts_Index extends Algolia_Index {
 	}
 
 	/**
+	 * Get default autocomplete config.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  NEXT
+	 *
+	 * @return array Autocomplete config.
+	 */
+	public function get_default_autocomplete_config() {
+		$default_config = parent::get_default_autocomplete_config();
+		$index_name     = $this->get_name();
+
+		/**
+		 * Filters the autocomplete debounce option for this index.
+		 *
+		 * @since NEXT
+		 *
+		 * @param int Debounce value in milliseconds.
+		 */
+		$debounce = apply_filters(
+			"algolia_autocomplete_debounce_{$index_name}",
+			$default_config['debounce']
+		);
+
+		$config = array(
+			'debounce' => $debounce,
+		);
+
+		return array_merge( $default_config, $config );
+	}
+
+	/**
 	 * Get the admin name for this index.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>

--- a/includes/indices/class-algolia-posts-index.php
+++ b/includes/indices/class-algolia-posts-index.php
@@ -70,7 +70,7 @@ final class Algolia_Posts_Index extends Algolia_Index {
 	 * Get default autocomplete config.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  NEXT
+	 * @since  2.10.0
 	 *
 	 * @return array Autocomplete config.
 	 */
@@ -81,7 +81,7 @@ final class Algolia_Posts_Index extends Algolia_Index {
 		/**
 		 * Filters the autocomplete debounce option for this index.
 		 *
-		 * @since NEXT
+		 * @since 2.10.0
 		 *
 		 * @param int Debounce value in milliseconds.
 		 */

--- a/includes/indices/class-algolia-searchable-posts-index.php
+++ b/includes/indices/class-algolia-searchable-posts-index.php
@@ -67,6 +67,37 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index {
 	}
 
 	/**
+	 * Get default autocomplete config.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  NEXT
+	 *
+	 * @return array Autocomplete config.
+	 */
+	public function get_default_autocomplete_config() {
+		$default_config = parent::get_default_autocomplete_config();
+		$index_name     = $this->get_name();
+
+		/**
+		 * Filters the autocomplete debounce value for this index.
+		 *
+		 * @since NEXT
+		 *
+		 * @param int Debounce value in milliseconds.
+		 */
+		$debounce = apply_filters(
+			"algolia_autocomplete_debounce_{$index_name}",
+			$default_config['debounce']
+		);
+
+		$config = array(
+			'debounce' => $debounce,
+		);
+
+		return array_merge( $default_config, $config );
+	}
+
+	/**
 	 * Get the admin name for this index.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>

--- a/includes/indices/class-algolia-searchable-posts-index.php
+++ b/includes/indices/class-algolia-searchable-posts-index.php
@@ -70,7 +70,7 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index {
 	 * Get default autocomplete config.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  NEXT
+	 * @since  2.10.0
 	 *
 	 * @return array Autocomplete config.
 	 */
@@ -81,7 +81,7 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index {
 		/**
 		 * Filters the autocomplete debounce value for this index.
 		 *
-		 * @since NEXT
+		 * @since 2.10.0
 		 *
 		 * @param int Debounce value in milliseconds.
 		 */

--- a/includes/indices/class-algolia-terms-index.php
+++ b/includes/indices/class-algolia-terms-index.php
@@ -248,16 +248,32 @@ final class Algolia_Terms_Index extends Algolia_Index {
 	 * @author WebDevStudios <contact@webdevstudios.com>
 	 * @since  1.0.0
 	 *
-	 * @return array
+	 * @return array Autocomplete config.
 	 */
 	public function get_default_autocomplete_config() {
+		$default_config = parent::get_default_autocomplete_config();
+		$index_name     = $this->get_name();
+
+		/**
+		 * Filters the autocomplete debounce option for this index.
+		 *
+		 * @since NEXT
+		 *
+		 * @param int Debounce value in milliseconds.
+		 */
+		$debounce = apply_filters(
+			"algolia_autocomplete_debounce_{$index_name}",
+			$default_config['debounce']
+		);
+
 		$config = array(
 			'position'        => 20,
 			'max_suggestions' => 3,
+			'debounce'        => $debounce,
 			'tmpl_suggestion' => 'autocomplete-term-suggestion',
 		);
 
-		return array_merge( parent::get_default_autocomplete_config(), $config );
+		return array_merge( $default_config, $config );
 	}
 
 	/**

--- a/includes/indices/class-algolia-terms-index.php
+++ b/includes/indices/class-algolia-terms-index.php
@@ -257,7 +257,7 @@ final class Algolia_Terms_Index extends Algolia_Index {
 		/**
 		 * Filters the autocomplete debounce option for this index.
 		 *
-		 * @since NEXT
+		 * @since 2.10.0
 		 *
 		 * @param int Debounce value in milliseconds.
 		 */

--- a/includes/indices/class-algolia-users-index.php
+++ b/includes/indices/class-algolia-users-index.php
@@ -234,16 +234,32 @@ final class Algolia_Users_Index extends Algolia_Index {
 	 * @author WebDevStudios <contact@webdevstudios.com>
 	 * @since  1.0.0
 	 *
-	 * @return array
+	 * @return array Autocomplete config.
 	 */
 	public function get_default_autocomplete_config() {
+		$default_config = parent::get_default_autocomplete_config();
+		$index_name     = $this->get_name();
+
+		/**
+		 * Filters the autocomplete debounce value for this index.
+		 *
+		 * @since NEXT
+		 *
+		 * @param int Debounce value in milliseconds.
+		 */
+		$debounce = apply_filters(
+			"algolia_autocomplete_debounce_{$index_name}",
+			$default_config['debounce']
+		);
+
 		$config = array(
 			'position'        => 30,
 			'max_suggestions' => 3,
+			'debounce       ' => $debounce,
 			'tmpl_suggestion' => 'autocomplete-user-suggestion',
 		);
 
-		return array_merge( parent::get_default_autocomplete_config(), $config );
+		return array_merge( $default_config, $config );
 	}
 
 	/**

--- a/includes/indices/class-algolia-users-index.php
+++ b/includes/indices/class-algolia-users-index.php
@@ -243,7 +243,7 @@ final class Algolia_Users_Index extends Algolia_Index {
 		/**
 		 * Filters the autocomplete debounce value for this index.
 		 *
-		 * @since NEXT
+		 * @since 2.10.0
 		 *
 		 * @param int Debounce value in milliseconds.
 		 */

--- a/templates/autocomplete.php
+++ b/templates/autocomplete.php
@@ -114,6 +114,7 @@
 					highlightPreTag: '__ais-highlight__',
 					highlightPostTag: '__/ais-highlight__'
 				} ),
+				debounce: config['debounce'],
 				templates: {
 					header: function () {
 						return wp.template( 'autocomplete-header' )( {


### PR DESCRIPTION
Closes https://webdevstudios.atlassian.net/browse/WPCE-330

- Adds single setting for Algolia Autocomplete debounce timeout with a default to zero, for disabled.
- Adds filters to allow for the debounce value to be set individually for each index.

![image](https://github.com/user-attachments/assets/41ef7534-15d6-499d-8690-72a076676b09)


Here's a plugin to test overriding the debounce timeout value for the `searchable_posts` index.

```
<?php
/**
 * Plugin Name:       Algolia Test Site Functions
 * Plugin URI:
 * Description:
 * Version:           1.0.0
 */

namespace AlgoliaTestFunctions;

add_filter( 'algolia_autocomplete_debounce_wp_searchable_posts', __NAMESPACE__ . '\searchable_posts_index_debounce' );
function searchable_posts_index_debounce() {
	return 5000;
}
```