### PR TITLE
An extra delete request during reindexing has been removed.

### DIFF
--- a/includes/indices/class-algolia-posts-index.php
+++ b/includes/indices/class-algolia-posts-index.php
@@ -404,6 +404,9 @@ final class Algolia_Posts_Index extends Algolia_Index {
 			 */
 			$should_wait = (bool) apply_filters( 'algolia_should_wait_on_delete_item', false, $post, $records );
 			$this->delete_item( $post, $should_wait );
+			if ( false === $this->reindexing ) {
+				$this->delete_item( $post, $should_wait );
+			}
 		}
 
 		parent::update_records( $post, $records );


### PR DESCRIPTION
During reindexing, a request is made to clear the index, 
and then each record (which no longer exists) is deleted again, which slows down the process.
Check it out - I hope it helps