### PR TITLE
Fixes #442: Running WP_CLI command wp algolia reindex --all would clear index even if --clear flag is not specified

### DIFF
--- a/includes/class-algolia-cli.php
+++ b/includes/class-algolia-cli.php
@@ -123,6 +123,8 @@ class Algolia_CLI {
 			$index->clear();
 			// translators: the placeholder will contain the name of the index.
 			WP_CLI::success( sprintf( __( 'Correctly cleared index "%s".', 'wp-search-with-algolia' ), $index->get_name() ) );
+		} else {
+			add_filter( 'algolia_clear_index_if_existing', '__return_false' );
 		}
 
 		$total_pages = $index->get_re_index_max_num_pages() - ( $from_batch - 1 );

--- a/includes/class-algolia-cli.php
+++ b/includes/class-algolia-cli.php
@@ -133,7 +133,7 @@ class Algolia_CLI {
 		}
 
 		if ( 0 === $total_pages ) {
-			$index->re_index( 1, array(), false ); // Don't clear the index, we've already done that.
+			$index->re_index( 1, array(), false ); // Reindex but don't clear the index, we've already done that.
 			WP_CLI::success( sprintf( 'Index %s was created but no entries were sent.', $index->get_name() ) );
 
 			return;
@@ -144,7 +144,7 @@ class Algolia_CLI {
 		$page = $from_batch;
 		do {
 			WP_CLI::log( sprintf( 'Indexing batch %s.', $page ) );
-			$index->re_index( $page++, array(), false ); // Don't clear the index, we've already done that.
+			$index->re_index( $page++, array(), false ); // Reindex but don't clear the index, we've already done that.
 			WP_CLI::log( sprintf( 'Indexed batch %s.', ( $page - 1 ) ) );
 			$progress->tick();
 		} while ( $page <= ( $total_pages + $from_batch - 1 ) );

--- a/includes/class-algolia-cli.php
+++ b/includes/class-algolia-cli.php
@@ -123,8 +123,6 @@ class Algolia_CLI {
 			$index->clear();
 			// translators: the placeholder will contain the name of the index.
 			WP_CLI::success( sprintf( __( 'Correctly cleared index "%s".', 'wp-search-with-algolia' ), $index->get_name() ) );
-		} else {
-			add_filter( 'algolia_clear_index_if_existing', '__return_false' );
 		}
 
 		$total_pages = $index->get_re_index_max_num_pages() - ( $from_batch - 1 );
@@ -135,7 +133,7 @@ class Algolia_CLI {
 		}
 
 		if ( 0 === $total_pages ) {
-			$index->re_index( 1 );
+			$index->re_index( 1, array(), false ); // Don't clear the index, we've already done that.
 			WP_CLI::success( sprintf( 'Index %s was created but no entries were sent.', $index->get_name() ) );
 
 			return;
@@ -146,7 +144,7 @@ class Algolia_CLI {
 		$page = $from_batch;
 		do {
 			WP_CLI::log( sprintf( 'Indexing batch %s.', $page ) );
-			$index->re_index( $page++ );
+			$index->re_index( $page++, array(), false ); // Don't clear the index, we've already done that.
 			WP_CLI::log( sprintf( 'Indexed batch %s.', ( $page - 1 ) ) );
 			$progress->tick();
 		} while ( $page <= ( $total_pages + $from_batch - 1 ) );

--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -420,12 +420,13 @@ abstract class Algolia_Index {
 	 * @since  1.0.0
 	 * @since  2.6.2 Added $specific_ids parameter
 	 *
-	 * @param int   $page         Page of the index.
-	 * @param array $specific_ids Array of IDs to specifically fetch and index.
+	 * @param int   $page                    Page of the index.
+	 * @param array $specific_ids            Array of IDs to specifically fetch and index.
+	 * @param bool  $clear_index_on_page_one Whether to clear the index or not if $page is set to 1.
 	 *
 	 * @throws InvalidArgumentException If the page is less than 1.
 	 */
-	public function re_index( $page, $specific_ids = [] ) {
+	public function re_index( $page, $specific_ids = [], $clear_index_on_page_one = true ) {
 		$page = (int) $page;
 
 		if ( $page < 1 ) {
@@ -433,7 +434,7 @@ abstract class Algolia_Index {
 		}
 
 		if ( 1 === $page ) {
-			$this->create_index_if_not_existing();
+			$this->create_index_if_not_existing( $clear_index_on_page_one );
 		}
 
 		$batch_size = (int) $this->get_re_index_batch_size();

--- a/includes/watchers/class-algolia-post-changes-watcher.php
+++ b/includes/watchers/class-algolia-post-changes-watcher.php
@@ -306,8 +306,11 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 			// Majority of the time, this if statement will hit
 			// for iterations where we will bundle up a re-index request.
 			if ( $current_total_posts === self::$pmxi_batch_size ) {
+				// Prevent clearing out our existing index.
+				add_filter( 'algolia_clear_index_if_existing', '__return_false' );
+
 				// Push up our current batch, clear out the queue, and increment our current page.
-				$this->index->re_index( 1, $this->posts_updated, false ); // Reindex but don't clear the index
+				$this->index->re_index( 1, $this->posts_updated );
 				$this->posts_updated = [];
 				$current_page++;
 
@@ -328,8 +331,11 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 
 				// We have finally collected them all.
 				if ( $current_remainder === $total_remainder ) {
+					// Still prevent clearing out our existing index.
+					add_filter( 'algolia_clear_index_if_existing', '__return_false' );
+
 					// Push up our final batch, clear out the queue just in case.
-					$this->index->re_index( 1, $this->posts_updated, false ); // Reindex but don't clear the index
+					$this->index->re_index( 1, $this->posts_updated );
 					$this->posts_updated = [];
 
 					// Clear out for next import run.

--- a/includes/watchers/class-algolia-post-changes-watcher.php
+++ b/includes/watchers/class-algolia-post-changes-watcher.php
@@ -306,11 +306,8 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 			// Majority of the time, this if statement will hit
 			// for iterations where we will bundle up a re-index request.
 			if ( $current_total_posts === self::$pmxi_batch_size ) {
-				// Prevent clearing out our existing index.
-				add_filter( 'algolia_clear_index_if_existing', '__return_false' );
-
 				// Push up our current batch, clear out the queue, and increment our current page.
-				$this->index->re_index( 1, $this->posts_updated );
+				$this->index->re_index( 1, $this->posts_updated, false ); // Don't clear the index
 				$this->posts_updated = [];
 				$current_page++;
 
@@ -331,11 +328,8 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 
 				// We have finally collected them all.
 				if ( $current_remainder === $total_remainder ) {
-					// Still prevent clearing out our existing index.
-					add_filter( 'algolia_clear_index_if_existing', '__return_false' );
-
 					// Push up our final batch, clear out the queue just in case.
-					$this->index->re_index( 1, $this->posts_updated );
+					$this->index->re_index( 1, $this->posts_updated, false ); // Don't clear the index
 					$this->posts_updated = [];
 
 					// Clear out for next import run.

--- a/includes/watchers/class-algolia-post-changes-watcher.php
+++ b/includes/watchers/class-algolia-post-changes-watcher.php
@@ -307,7 +307,7 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 			// for iterations where we will bundle up a re-index request.
 			if ( $current_total_posts === self::$pmxi_batch_size ) {
 				// Push up our current batch, clear out the queue, and increment our current page.
-				$this->index->re_index( 1, $this->posts_updated, false ); // Don't clear the index
+				$this->index->re_index( 1, $this->posts_updated, false ); // Reindex but don't clear the index
 				$this->posts_updated = [];
 				$current_page++;
 
@@ -329,7 +329,7 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 				// We have finally collected them all.
 				if ( $current_remainder === $total_remainder ) {
 					// Push up our final batch, clear out the queue just in case.
-					$this->index->re_index( 1, $this->posts_updated, false ); // Don't clear the index
+					$this->index->re_index( 1, $this->posts_updated, false ); // Reindex but don't clear the index
 					$this->posts_updated = [];
 
 					// Clear out for next import run.


### PR DESCRIPTION
Fixes #442 

Fixes an issue where
- The WP-CLI command without the `--clear` flag would call `$index->re_index( 1 );`
- And `$index->re_index( 1 );` would trigger the `$index->create_index_if_not_existing()` function
- And `$index->create_index_if_not_existing()` would clear the index if the index already exists (which was specifically not chosen to do when calling the CLI command).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208952565138971