### PR TITLE
An extra delete request during reindexing has been removed.

### DIFF
--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -69,6 +69,17 @@ abstract class Algolia_Index {
 	 */
 	protected $reindexing = false;
 
+
+	/**
+	 * Remove unnecessary deletions from the cleaned index.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  2.8.3
+	 *
+	 * @var bool
+	 */
+	protected $already_cleared = false;
+
 	/**
 	 * Get the admin name for this index.
 	 *
@@ -435,6 +446,12 @@ abstract class Algolia_Index {
 		if ( 1 === $page ) {
 			$this->create_index_if_not_existing();
 		}
+
+		$this->already_cleared = empty( $specific_ids ) && (bool) apply_filters(
+			'algolia_clear_index_if_existing',
+			true,
+			$this->get_id()
+		);
 
 		$batch_size = (int) $this->get_re_index_batch_size();
 

--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -344,7 +344,7 @@ abstract class Algolia_Index {
 	 */
 	protected function update_records( $item, array $records ) {
 
-		if ( empty( $records ) ) {
+		if ( empty( $records ) && ! $this->already_cleared ) {
 			$this->delete_item( $item );
 			return;
 		}

--- a/includes/indices/class-algolia-posts-index.php
+++ b/includes/indices/class-algolia-posts-index.php
@@ -403,7 +403,9 @@ final class Algolia_Posts_Index extends Algolia_Index {
 			 * @return bool
 			 */
 			$should_wait = (bool) apply_filters( 'algolia_should_wait_on_delete_item', false, $post, $records );
-			$this->delete_item( $post, $should_wait );
+			if ( false === $this->reindexing ) {
+				$this->delete_item( $post, $should_wait );
+			}
 		}
 
 		parent::update_records( $post, $records );

--- a/includes/indices/class-algolia-posts-index.php
+++ b/includes/indices/class-algolia-posts-index.php
@@ -389,7 +389,7 @@ final class Algolia_Posts_Index extends Algolia_Index {
 	private function update_post_records( WP_Post $post, array $records ) {
 		// If there are no records, parent `update_records` will take care of the deletion.
 		// In case of posts, we ALWAYS need to delete existing records.
-		if ( ! empty( $records ) ) {
+		if ( ! empty( $records ) && ! $this->already_cleared ) {
 			/**
 			 * Filters whether or not to use synchronous wait on record update operations.
 			 *
@@ -403,9 +403,7 @@ final class Algolia_Posts_Index extends Algolia_Index {
 			 * @return bool
 			 */
 			$should_wait = (bool) apply_filters( 'algolia_should_wait_on_delete_item', false, $post, $records );
-			if ( false === $this->reindexing ) {
-				$this->delete_item( $post, $should_wait );
-			}
+			$this->delete_item( $post, $should_wait );
 		}
 
 		parent::update_records( $post, $records );

--- a/includes/indices/class-algolia-searchable-posts-index.php
+++ b/includes/indices/class-algolia-searchable-posts-index.php
@@ -370,7 +370,7 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index {
 	private function update_post_records( WP_Post $post, array $records ) {
 		// If there are no records, parent `update_records` will take care of the deletion.
 		// In case of posts, we ALWAYS need to delete existing records.
-		if ( ! empty( $records ) ) {
+		if ( ! empty( $records ) && ! $this->already_cleared ) {
 			/**
 			 * Filters whether or not to use synchronous wait on record update operations.
 			 *


### PR DESCRIPTION
During reindexing, a request is made to clear the index, and then each record (which no longer exists) is deleted again, which slows down the process (reindexing takes hours instead of minutes)