### PR TITLE
de-internationalize a message that should not be getting hit ever, bu…

### DIFF
--- a/classmap.php
+++ b/classmap.php
@@ -25,7 +25,7 @@ apply_filters_deprecated(
 	[ true ],
 	'2.3.2',
 	'',
-	esc_html__( 'The "algolia_should_require_search_client" filter is deprecated and no longer has any effect.', 'wp-search-with-algolia' )
+	'The "algolia_should_require_search_client" filter is deprecated and no longer has any effect.',
 );
 
 // Autoload vendor dependencies, that have been prefixed to prevent namespace collision.


### PR DESCRIPTION
…t still throws possible WP notices about _load_textdomain_just_in_time called incorrectly

This PR handles removal of i18n in a spot that loads very early. I can not get a filter to actually hook into this, and I feel we're fine with removing that i18n.