### PR TITLE
Settings for choosing Instantsearch template version.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -128,7 +128,10 @@ All development is handled on [GitHub](https://github.com/WebDevStudios/wp-searc
 
 Follow along with the changelog on [Github](https://github.com/WebDevStudios/wp-search-with-algolia/releases).
 
-<<<<<<< HEAD
+= 2.9.0 =
+* Updated: MAJOR TEMPLATES UPDATE! Removed hogan.js/string-based templates in the Instantsearch.php template file. We're not removing the dependencies of wp-util and underscores libraries yet, for users with customized instantsearch.php that's still using the original style, but may in the future.
+* Added: ability to customize Default Headers for Algolia Search Client configuration.
+
 = 2.8.3 =
 * Fixed: "Function _load_textdomain_just_in_time was called incorrectly" notices.
 
@@ -136,11 +139,6 @@ Follow along with the changelog on [Github](https://github.com/WebDevStudios/wp-
 * Updated: Wording and UI details around the settings pages for better and more accurate reflection.
 * Updated: Confirmed compatibility with WP 6.7.x
 * Added: New page regarding Premium support from WebDevStudios. Let's work together.
-=======
-= 2.9.0 =
-* Updated: MAJOR TEMPLATES UPDATE! Removed hogan.js/string-based templates in the Instantsearch.php template file. We're not removing the dependencies of wp-util and underscores libraries yet, for users with customized instantsearch.php that's still using the original style, but may in the future.
-* Added: ability to customize Default Headers for Algolia Search Client configuration.
->>>>>>> 276faf9 (version bumps for the branch, changelog)
 
 = 2.8.1 =
 * Updated: WP Search with Algolia Pro features list for version 1.4.0

--- a/algolia.php
+++ b/algolia.php
@@ -3,13 +3,8 @@
  * Plugin Name:       WP Search with Algolia
  * Plugin URI:        https://github.com/WebDevStudios/wp-search-with-algolia
  * Description:       Integrate the powerful Algolia search service with WordPress
-<<<<<<< HEAD
- * Version:           2.8.3
- * Requires at least: 5.3
-=======
  * Version:           2.9.0
- * Requires at least: 5.0
->>>>>>> ddc3d54 (update main php file version)
+ * Requires at least: 5.3
  * Requires PHP:      7.4
  * Author:            WebDevStudios
  * Author URI:        https://webdevstudios.com

--- a/includes/admin/class-algolia-admin-page-native-search.php
+++ b/includes/admin/class-algolia-admin-page-native-search.php
@@ -121,7 +121,17 @@ class Algolia_Admin_Page_Native_Search {
 			$this->section
 		);
 
+		add_settings_field(
+			'algolia_search_template_version',
+			esc_html__( 'Template version', 'wp-search-with-algolia' ),
+			[ $this, 'search_template_version' ],
+			$this->slug,
+			$this->section
+		);
+
 		register_setting( $this->option_group, 'algolia_override_native_search', array( $this, 'sanitize_override_native_search' ) );
+
+		register_setting( $this->option_group, 'algolia_search_template_version', [ $this, 'sanitize_override_native_search' ] );
 	}
 
 	/**
@@ -134,6 +144,17 @@ class Algolia_Admin_Page_Native_Search {
 		$value = $this->plugin->get_settings()->get_override_native_search();
 
 		require_once dirname( __FILE__ ) . '/partials/form-override-search-option.php';
+	}
+
+	/**
+	 * Override native search callback.
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  1.0.0
+	 */
+	public function search_template_version() {
+		$value = $this->plugin->get_settings()->get_search_template_version();
+
+		require_once dirname( __FILE__ ) . '/partials/form-override-search-version-option.php';
 	}
 
 	/**

--- a/includes/admin/class-algolia-admin-page-native-search.php
+++ b/includes/admin/class-algolia-admin-page-native-search.php
@@ -122,16 +122,16 @@ class Algolia_Admin_Page_Native_Search {
 		);
 
 		add_settings_field(
-			'algolia_search_template_version',
-			esc_html__( 'Template version', 'wp-search-with-algolia' ),
-			[ $this, 'search_template_version' ],
+			'algolia_instantsearch_template_version',
+			esc_html__( 'Instantsearch Template version', 'wp-search-with-algolia' ),
+			[ $this, 'instantsearch_template_version' ],
 			$this->slug,
 			$this->section
 		);
 
 		register_setting( $this->option_group, 'algolia_override_native_search', array( $this, 'sanitize_override_native_search' ) );
 
-		register_setting( $this->option_group, 'algolia_search_template_version', [ $this, 'sanitize_override_native_search' ] );
+		register_setting( $this->option_group, 'algolia_instantsearch_template_version', [ $this, 'sanitize_override_native_search' ] );
 	}
 
 	/**
@@ -151,8 +151,8 @@ class Algolia_Admin_Page_Native_Search {
 	 * @author WebDevStudios <contact@webdevstudios.com>
 	 * @since  1.0.0
 	 */
-	public function search_template_version() {
-		$value = $this->plugin->get_settings()->get_search_template_version();
+	public function instantsearch_template_version() {
+		$value = $this->plugin->get_settings()->get_instantsearch_template_version();
 
 		require_once dirname( __FILE__ ) . '/partials/form-override-search-version-option.php';
 	}

--- a/includes/admin/class-algolia-admin-page-native-search.php
+++ b/includes/admin/class-algolia-admin-page-native-search.php
@@ -147,9 +147,10 @@ class Algolia_Admin_Page_Native_Search {
 	}
 
 	/**
-	 * Override native search callback.
+	 * Get Instantsearch template version
+	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  1.0.0
+	 * @since  2.9.0
 	 */
 	public function instantsearch_template_version() {
 		$value = $this->plugin->get_settings()->get_instantsearch_template_version();

--- a/includes/admin/partials/form-override-search-version-option.php
+++ b/includes/admin/partials/form-override-search-version-option.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Form override search option admin template partial.
+ *
+ * @author  WebDevStudios <contact@webdevstudios.com>
+ * @since   1.0.0
+ *
+ * @package WebDevStudios\WPSWA
+ */
+
+?>
+
+<div class="input-radio">
+	<label>
+		<input type="radio" value="legacy"
+			name="algolia_search_template_version" <?php checked( $value, 'legacy' ); ?>>
+		<?php esc_html_e( 'Legacy', 'wp-search-with-algolia' ); ?>
+	</label>
+	<div class="radio-info">
+		<?php
+		echo wp_kses(
+			__(
+				'Utilizes WP Utils library.',
+				'wp-search-with-algolia'
+			),
+			[
+				'br' => [],
+			]
+		);
+		?>
+	</div>
+
+	<label>
+		<input type="radio" value="modern"
+			name="algolia_search_template_version" <?php checked( $value, 'modern' ); ?>>
+		<?php esc_html_e( 'Modern', 'wp-search-with-algolia' ); ?>
+	</label>
+	<div class="radio-info">
+		<?php
+		echo wp_kses(
+			__(
+				'Uses Javascript string literals and more in line with Algolia documentation.',
+				'wp-search-with-algolia'
+			),
+			[
+				'br' => [],
+			]
+		);
+		?>
+	</div>
+</div>

--- a/includes/admin/partials/form-override-search-version-option.php
+++ b/includes/admin/partials/form-override-search-version-option.php
@@ -3,7 +3,7 @@
  * Form override search option admin template partial.
  *
  * @author  WebDevStudios <contact@webdevstudios.com>
- * @since   1.0.0
+ * @since   2.9.0
  *
  * @package WebDevStudios\WPSWA
  */

--- a/includes/admin/partials/form-override-search-version-option.php
+++ b/includes/admin/partials/form-override-search-version-option.php
@@ -39,7 +39,7 @@
 		<?php
 		echo wp_kses(
 			__(
-				'Uses Javascript string literals and more in line with Algolia documentation.',
+				'Uses Javascript template string literals and is more in line with Algolia documentation.',
 				'wp-search-with-algolia'
 			),
 			[

--- a/includes/class-algolia-settings.php
+++ b/includes/class-algolia-settings.php
@@ -29,6 +29,7 @@ class Algolia_Settings {
 		add_option( 'algolia_autocomplete_enabled', 'no' );
 		add_option( 'algolia_autocomplete_config', array() );
 		add_option( 'algolia_override_native_search', 'native' );
+		add_option( 'algolia_instantsearch_template_version', 'legacy' );
 		add_option( 'algolia_index_name_prefix', 'wp_' );
 		add_option( 'algolia_api_is_reachable', 'no' );
 		add_option( 'algolia_powered_by_enabled', 'yes' );
@@ -494,5 +495,27 @@ class Algolia_Settings {
 	 */
 	public function disable_powered_by() {
 		update_option( 'algolia_powered_by_enabled', 'no' );
+	}
+
+	/**
+	 * Return the version keyword for Autocomplete version to use.
+	 * @return mixed|null
+	 * @since NEXT
+	 */
+	public function get_instantsearch_template_version() {
+		$chosen = get_option( 'algolia_instantsearch_template_version', 'legacy' );
+
+		return apply_filters( 'algolia_instantsearch_template_version', $chosen );
+	}
+
+	/**
+	 * Return whether or not the keyword version is set to 'modern' or 'legacy'.
+	 * @return bool
+	 * @since NEXT
+	 */
+	public function should_use_instantsearch_modern() {
+		$version = $this->get_instantsearch_template_version();
+
+		return $version === 'modern';
 	}
 }

--- a/includes/class-algolia-settings.php
+++ b/includes/class-algolia-settings.php
@@ -498,9 +498,11 @@ class Algolia_Settings {
 	}
 
 	/**
-	 * Return the version keyword for Autocomplete version to use.
+	 * Return the version keyword for Instantsearch version to use.
+	 *
+	 * @since 2.9.0
+	 *
 	 * @return mixed|null
-	 * @since NEXT
 	 */
 	public function get_instantsearch_template_version() {
 		$chosen = get_option( 'algolia_instantsearch_template_version', 'legacy' );
@@ -510,8 +512,10 @@ class Algolia_Settings {
 
 	/**
 	 * Return whether or not the keyword version is set to 'modern' or 'legacy'.
+	 *
+	 * @since 2.9.0
+	 *
 	 * @return bool
-	 * @since NEXT
 	 */
 	public function should_use_instantsearch_modern() {
 		$version = $this->get_instantsearch_template_version();


### PR DESCRIPTION
This PR merges in settings details for choosing InstantSearch template version to use.

The release290 branch should already have the "modern" template file merged in.