### PR TITLE
Feature/447 instant search posts per page

### DIFF
--- a/includes/class-algolia-template-loader.php
+++ b/includes/class-algolia-template-loader.php
@@ -75,18 +75,19 @@ class Algolia_Template_Loader {
 		$settings            = $this->plugin->get_settings();
 		$autocomplete_config = $this->plugin->get_autocomplete_config();
 
-		$config = array(
-			'debug'              => defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG,
-			'application_id'     => $settings->get_application_id(),
-			'search_api_key'     => $settings->get_search_api_key(),
-			'powered_by_enabled' => $settings->is_powered_by_enabled(),
-			'query'              => get_search_query(),
-			'autocomplete'       => array(
+		$config = [
+			'debug'                => defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG,
+			'application_id'       => $settings->get_application_id(),
+			'search_api_key'       => $settings->get_search_api_key(),
+			'powered_by_enabled'   => $settings->is_powered_by_enabled(),
+			'search_hits_per_page' => get_option( 'posts_per_page' ),
+			'query'                => get_search_query(),
+			'indices'              => [],
+			'autocomplete'         => [
 				'sources'        => $autocomplete_config->get_config(),
 				'input_selector' => (string) apply_filters( 'algolia_autocomplete_input_selector', "input[name='s']:not(.no-autocomplete):not(#adminbar-search)" ),
-			),
-			'indices'            => array(),
-		);
+			],
+		];
 
 		// Inject all the indices into the config to ease instantsearch.js integrations.
 		$indices = $this->plugin->get_indices(

--- a/templates/instantsearch-modern.php
+++ b/templates/instantsearch-modern.php
@@ -108,7 +108,7 @@ get_header();
 					// Configure widget
 					// https://www.algolia.com/doc/api-reference/widgets/configure/js/
 					instantsearch.widgets.configure({
-						hitsPerPage: 10,
+						hitsPerPage: algolia.search_hits_per_page,
 					}),
 
 					// Hits widget

--- a/templates/instantsearch.php
+++ b/templates/instantsearch.php
@@ -5,7 +5,7 @@
  * @author  WebDevStudios <contact@webdevstudios.com>
  * @since   1.0.0
  *
- * @version 2.7.1
+ * @version 2.9.0
  * @package WebDevStudios\WPSWA
  */
 
@@ -121,7 +121,7 @@ get_header();
 					}),
 
 					instantsearch.widgets.configure({
-						hitsPerPage: 10,
+						hitsPerPage: algolia.search_hits_per_page,
 					}),
 
 					/* Hits widget */


### PR DESCRIPTION
This PR adds support for the Instantsearch config to read from our "posts per page" option instead of hard coding to 10 by default.