### PR TITLE
Sync parameters for "get_items" method for abstract, term and user queries.

### DIFF
--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -716,12 +716,13 @@ abstract class Algolia_Index {
 	 * @author WebDevStudios <contact@webdevstudios.com>
 	 * @since  1.0.0
 	 *
-	 * @param int $page       The page.
-	 * @param int $batch_size The batch size.
+	 * @param int   $page         The page.
+	 * @param int   $batch_size   The batch size.
+	 * @param array $specific_ids Array of IDs to retrieve and index.
 	 *
 	 * @return array
 	 */
-	abstract protected function get_items( $page, $batch_size );
+	abstract protected function get_items( $page, $batch_size, $specific_ids = [] );
 
 	/**
 	 * Get default autocomplete config.

--- a/includes/indices/class-algolia-posts-index.php
+++ b/includes/indices/class-algolia-posts-index.php
@@ -457,7 +457,7 @@ final class Algolia_Posts_Index extends Algolia_Index {
 	 *
 	 * @param int   $page         The page.
 	 * @param int   $batch_size   The batch size.
-	 * @param array $specific_ids Array of IDs to specifically fetch and index.
+	 * @param array $specific_ids Array of post IDs to retrieve and index.
 	 *
 	 * @return array
 	 */
@@ -471,7 +471,7 @@ final class Algolia_Posts_Index extends Algolia_Index {
 			'paged'            => $page,
 			'suppress_filters' => true,
 		];
-		if ( ! empty( $specific_ids ) ) {
+		if ( ! empty( $specific_ids ) && is_array( $specific_ids ) ) {
 			$args['post__in'] = (array) $specific_ids;
 		}
 		$query = new WP_Query( $args );

--- a/includes/indices/class-algolia-searchable-posts-index.php
+++ b/includes/indices/class-algolia-searchable-posts-index.php
@@ -441,7 +441,7 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index {
 	 *
 	 * @param int   $page         The page.
 	 * @param int   $batch_size   The batch size.
-	 * @param array $specific_ids Array of IDs to specifically fetch and index.
+	 * @param array $specific_ids Array of post IDs to retrieve and index.
 	 *
 	 * @return array
 	 */
@@ -458,7 +458,7 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index {
 			'lazy_load_term_meta'    => false,
 			'update_post_term_cache' => false,
 		];
-		if ( ! empty( $specific_ids ) ) {
+		if ( ! empty( $specific_ids ) && is_array( $specific_ids ) ) {
 			$args['post__in'] = (array) $specific_ids;
 		}
 		$query = new WP_Query( $args );

--- a/includes/indices/class-algolia-terms-index.php
+++ b/includes/indices/class-algolia-terms-index.php
@@ -195,24 +195,29 @@ final class Algolia_Terms_Index extends Algolia_Index {
 	 * @author WebDevStudios <contact@webdevstudios.com>
 	 * @since  1.0.0
 	 *
-	 * @param int $page       The page.
-	 * @param int $batch_size The batch size.
+	 * @param int   $page         The page.
+	 * @param int   $batch_size   The batch size.
+	 * @param array $specific_ids Array of terms to retrieve and index.
 	 *
 	 * @return array
 	 */
-	protected function get_items( $page, $batch_size ) {
+	protected function get_items( $page, $batch_size, $specific_ids = [] ) {
 		$offset = $batch_size * ( $page - 1 );
 
-		$args = array(
+		$args = [
+			'taxonomy' => $this->taxonomy,
 			'order'      => 'ASC',
 			'orderby'    => 'id',
 			'offset'     => $offset,
 			'number'     => $batch_size,
 			'hide_empty' => false, // Let users choose what to index.
-		);
+		];
 
-		// We use prior to 4.5 syntax for BC purposes.
-		return get_terms( $this->taxonomy, $args );
+		if ( ! empty( $specific_ids ) && is_array( $specific_ids ) ) {
+			$args['include'] = $specific_ids;
+		}
+
+		return get_terms( $args );
 	}
 
 	/**

--- a/includes/indices/class-algolia-users-index.php
+++ b/includes/indices/class-algolia-users-index.php
@@ -185,20 +185,25 @@ final class Algolia_Users_Index extends Algolia_Index {
 	 * @author WebDevStudios <contact@webdevstudios.com>
 	 * @since  1.0.0
 	 *
-	 * @param int $page       The page.
-	 * @param int $batch_size The batch size.
+	 * @param int   $page         The page.
+	 * @param int   $batch_size   The batch size.
+	 * @param array $specific_ids Array of user to retrieve and index.
 	 *
 	 * @return array
 	 */
-	protected function get_items( $page, $batch_size ) {
+	protected function get_items( $page, $batch_size, $specific_ids = [] ) {
 		$offset = $batch_size * ( $page - 1 );
 
-		$args = array(
+		$args = [
 			'order'   => 'ASC',
 			'orderby' => 'ID',
 			'offset'  => $offset,
 			'number'  => $batch_size,
-		);
+		];
+
+		if ( ! empty( $specific_ids ) && is_array( $specific_ids ) ) {
+			$args['include'] = $specific_ids;
+		}
 
 		// We use prior to 4.5 syntax for BC purposes, no `paged` arg.
 		return get_users( $args );


### PR DESCRIPTION
This PR syncs parameters for the "get_items" method for abstract, term and user queries.

We added specifying IDs for WP All Import integration a ways back, and this PR fills in the term/user methods while also hardening the OOP "contract" with setting this on the abstract method as well.