### PR TITLE
return early in template loader if we are only integrating with native search template

### DIFF
--- a/includes/class-algolia-template-loader.php
+++ b/includes/class-algolia-template-loader.php
@@ -35,6 +35,11 @@ class Algolia_Template_Loader {
 	public function __construct( Algolia_Plugin $plugin ) {
 		$this->plugin = $plugin;
 
+		$settings = $this->plugin->get_settings();
+		if ( ! $this->should_load_autocomplete() && ! $settings->should_override_search_with_instantsearch() ) {
+			return;
+		}
+
 		$in_footer = Algolia_Utils::get_scripts_in_footer_argument();
 
 		// Inject Algolia configuration in a JavaScript variable.


### PR DESCRIPTION
This PR prevents loading of frontend data and assets if only "native search template" integration is set up. That functionality is all handled on the backend and does not need to expose configuration data to the frontend.