### PR TITLE
Fix/467 query sync

### DIFF
--- a/includes/indices/class-algolia-posts-index.php
+++ b/includes/indices/class-algolia-posts-index.php
@@ -438,11 +438,13 @@ final class Algolia_Posts_Index extends Algolia_Index {
 	 */
 	protected function get_re_index_items_count() {
 		$query = new WP_Query(
-			array(
-				'post_type'        => $this->post_type,
-				'post_status'      => 'any', // Let the `should_index` take care of the filtering.
-				'suppress_filters' => true,
-			)
+			[
+				'post_type'              => $this->post_type,
+				'post_status'            => 'any', // Let the `should_index` take care of the filtering.
+				'suppress_filters'       => true,
+				'cache_results'          => false,
+				'update_post_term_cache' => false,
+			]
 		);
 
 		return (int) $query->found_posts;

--- a/includes/indices/class-algolia-searchable-posts-index.php
+++ b/includes/indices/class-algolia-searchable-posts-index.php
@@ -419,14 +419,13 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index {
 	 */
 	protected function get_re_index_items_count() {
 		$query = new WP_Query(
-			array(
+			[
 				'post_type'              => $this->post_types,
 				'post_status'            => 'any', // Let the `should_index` take care of the filtering.
 				'suppress_filters'       => true,
 				'cache_results'          => false,
-				'lazy_load_term_meta'    => false,
 				'update_post_term_cache' => false,
-			)
+			]
 		);
 
 		return (int) $query->found_posts;


### PR DESCRIPTION
This PR adjusts the two `WP_Query` calls for `get_re_index_items_count()` methods to match.