### PR TITLE
move our config setting fetching to our factory getter instead of direct new settings instantiation

### DIFF
--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -733,8 +733,8 @@ abstract class Algolia_Index {
 	 * @return array Autocomplete config.
 	 */
 	public function get_default_autocomplete_config() {
-		$plugin_settings = new \Algolia_Settings();
-		$debounce        = $plugin_settings->get_autocomplete_debounce();
+		$plugin   = Algolia_Plugin_Factory::create();
+		$debounce = $plugin->get_settings()->get_autocomplete_debounce();
 
 		return array(
 			'index_id'        => $this->get_id(),


### PR DESCRIPTION
This PR fixes #493 which has most all of our admin notifications around Settings API showing on Autocomplete save.