### PR TITLE
Feature/488 algolia client update

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,7 +1,7 @@
 === WP Search with Algolia ===
 Contributors: WebDevStudios, williamsba1, tw2113, mrasharirfan, scottbasgaard, gregrickaby, richaber, daveromsey
 Tags: search, algolia, autocomplete, instantsearch, relevance search, faceted search, find-as-you-type search, ecommerce, seo, woocommerce, advanced search
-Requires at least: 5.3
+Requires at least: 6.7.2
 Tested up to: 6.8.1
 Requires PHP: 7.4
 Stable tag: 2.10.1

--- a/algolia.php
+++ b/algolia.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://github.com/WebDevStudios/wp-search-with-algolia
  * Description:       Integrate the powerful Algolia search service with WordPress
  * Version:           2.10.1
- * Requires at least: 5.3
+ * Requires at least: 6.7.2
  * Requires PHP:      7.4
  * Author:            WebDevStudios
  * Author URI:        https://webdevstudios.com

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     "composer/installers": "~1.0"
   },
   "require-dev": {
-    "algolia/algoliasearch-client-php": "^3.3",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
     "phpcompatibility/phpcompatibility-wp": "^2.1.2",
     "wp-coding-standards/wpcs": "^2.3.0",
@@ -30,7 +29,8 @@
     "psr/simple-cache": "^1.0",
     "brianhenryie/strauss": "^0.11.1",
     "php-stubs/wp-cli-stubs": "^2.7",
-    "php-stubs/wordpress-stubs": "^6.1"
+    "php-stubs/wordpress-stubs": "^6.1",
+    "algolia/algoliasearch-client-php": "3.4.2"
   },
   "extra": {
     "installer-name": "wp-search-with-algolia",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ea03bd5f2219c0f7e959bb26d9f1383",
+    "content-hash": "1003107e7a3dd71812f7951ccfc3e581",
     "packages": [
         {
             "name": "composer/installers",
@@ -161,24 +161,24 @@
     "packages-dev": [
         {
             "name": "algolia/algoliasearch-client-php",
-            "version": "3.3.2",
+            "version": "3.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/algolia/algoliasearch-client-php.git",
-                "reference": "cbd07bc0bb7303ff71e238d2d6284ef8469e1d5a"
+                "reference": "7505959737f7944507be7ef476752ad761873c4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/algolia/algoliasearch-client-php/zipball/cbd07bc0bb7303ff71e238d2d6284ef8469e1d5a",
-                "reference": "cbd07bc0bb7303ff71e238d2d6284ef8469e1d5a",
+                "url": "https://api.github.com/repos/algolia/algoliasearch-client-php/zipball/7505959737f7944507be7ef476752ad761873c4a",
+                "reference": "7505959737f7944507be7ef476752ad761873c4a",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "ext-json": "*",
                 "ext-mbstring": "*",
-                "php": "^7.2 || ^8.0",
-                "psr/http-message": "^1.0",
+                "php": "^7.3 || ^8.0",
+                "psr/http-message": "^1.1 || ^2.0",
                 "psr/log": "^1.0 || ^2.0 || ^3.0",
                 "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
             },
@@ -229,9 +229,9 @@
             ],
             "support": {
                 "issues": "https://github.com/algolia/algoliasearch-client-php/issues",
-                "source": "https://github.com/algolia/algoliasearch-client-php/tree/3.3.2"
+                "source": "https://github.com/algolia/algoliasearch-client-php/tree/3.4.2"
             },
-            "time": "2022-09-22T08:21:13+00:00"
+            "time": "2025-01-22T11:13:54+00:00"
         },
         {
             "name": "brianhenryie/strauss",
@@ -1766,25 +1766,25 @@
         },
         {
             "name": "psr/http-message",
-            "version": "1.0.1",
+            "version": "1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -1813,9 +1813,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-message/tree/master"
+                "source": "https://github.com/php-fig/http-message/tree/1.1"
             },
-            "time": "2016-08-06T14:39:51+00:00"
+            "time": "2023-04-04T09:50:52+00:00"
         },
         {
             "name": "psr/log",
@@ -3621,12 +3621,12 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.2"
+        "php": ">=7.4"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/AccountClient.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/AccountClient.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Algolia.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Algolia.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 
@@ -16,7 +16,7 @@ use WebDevStudios\WPSWA\Psr\SimpleCache\CacheInterface;
 
 final class Algolia
 {
-    const VERSION = '3.3.2';
+    const VERSION = '3.4.2';
 
     /**
      * Holds an instance of the simple cache repository (PSR-16).

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/AnalyticsClient.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/AnalyticsClient.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Cache/FileCacheDriver.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Cache/FileCacheDriver.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Cache/NullCacheDriver.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Cache/NullCacheDriver.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Config/AbstractConfig.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Config/AbstractConfig.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Config/AnalyticsConfig.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Config/AnalyticsConfig.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Config/InsightsConfig.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Config/InsightsConfig.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Config/PersonalizationConfig.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Config/PersonalizationConfig.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Config/PlacesConfig.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Config/PlacesConfig.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Config/RecommendConfig.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Config/RecommendConfig.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Config/RecommendationConfig.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Config/RecommendationConfig.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Config/SearchConfig.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Config/SearchConfig.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Exceptions/AlgoliaException.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Exceptions/AlgoliaException.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Exceptions/BadRequestException.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Exceptions/BadRequestException.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Exceptions/CannotWaitException.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Exceptions/CannotWaitException.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Exceptions/MissingObjectId.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Exceptions/MissingObjectId.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Exceptions/NotFoundException.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Exceptions/NotFoundException.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Exceptions/ObjectNotFoundException.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Exceptions/ObjectNotFoundException.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Exceptions/RequestException.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Exceptions/RequestException.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Exceptions/RetriableException.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Exceptions/RetriableException.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Exceptions/UnreachableException.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Exceptions/UnreachableException.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Exceptions/ValidUntilNotFoundException.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Exceptions/ValidUntilNotFoundException.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/CurlHttpClient.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/CurlHttpClient.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/GuzzleHttpClient.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/GuzzleHttpClient.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 
@@ -20,7 +20,7 @@ final class GuzzleHttpClient implements HttpClientInterface
 {
     private $client;
 
-    public function __construct(GuzzleClient $client = null)
+    public function __construct(?GuzzleClient $client = null)
     {
         $this->client = $client ?: static::buildClient();
     }

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/HttpClientInterface.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/HttpClientInterface.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/Psr7/BufferStream.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/Psr7/BufferStream.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 
@@ -38,12 +38,12 @@ class BufferStream implements StreamInterface
         $this->hwm = $hwm;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getContents();
     }
 
-    public function getContents()
+    public function getContents(): string
     {
         $buffer = $this->buffer;
         $this->buffer = '';
@@ -51,7 +51,7 @@ class BufferStream implements StreamInterface
         return $buffer;
     }
 
-    public function close()
+    public function close(): void
     {
         $this->buffer = '';
     }
@@ -61,42 +61,42 @@ class BufferStream implements StreamInterface
         $this->close();
     }
 
-    public function getSize()
+    public function getSize(): ?int
     {
         return strlen($this->buffer);
     }
 
-    public function isReadable()
+    public function isReadable(): bool
     {
         return true;
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return true;
     }
 
-    public function isSeekable()
+    public function isSeekable(): bool
     {
         return false;
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->seek(0);
     }
 
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek(int $offset, int $whence = SEEK_SET): void
     {
         throw new \RuntimeException('Cannot seek a BufferStream');
     }
 
-    public function eof()
+    public function eof(): bool
     {
         return 0 === strlen($this->buffer);
     }
 
-    public function tell()
+    public function tell(): int
     {
         throw new \RuntimeException('Cannot determine the position of a BufferStream');
     }
@@ -104,7 +104,7 @@ class BufferStream implements StreamInterface
     /**
      * Reads data from the buffer.
      */
-    public function read($length)
+    public function read(int $length): string
     {
         $currentLength = strlen($this->buffer);
 
@@ -124,7 +124,7 @@ class BufferStream implements StreamInterface
     /**
      * Writes data to the buffer.
      */
-    public function write($string)
+    public function write(string $string): int
     {
         $this->buffer .= $string;
 
@@ -136,7 +136,7 @@ class BufferStream implements StreamInterface
         return strlen($string);
     }
 
-    public function getMetadata($key = null)
+    public function getMetadata(?string $key = null)
     {
         if ('hwm' == $key) {
             return $this->hwm;

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/Psr7/PumpStream.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/Psr7/PumpStream.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 
@@ -57,7 +57,7 @@ class PumpStream implements StreamInterface
         $this->buffer = new BufferStream();
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         try {
             return copy_to_string($this);
@@ -66,7 +66,7 @@ class PumpStream implements StreamInterface
         }
     }
 
-    public function close()
+    public function close(): void
     {
         $this->detach();
     }
@@ -77,52 +77,52 @@ class PumpStream implements StreamInterface
         $this->source = null;
     }
 
-    public function getSize()
+    public function getSize(): ?int
     {
         return $this->size;
     }
 
-    public function tell()
+    public function tell(): int
     {
         return $this->tellPos;
     }
 
-    public function eof()
+    public function eof(): bool
     {
         return !$this->source;
     }
 
-    public function isSeekable()
+    public function isSeekable(): bool
     {
         return false;
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->seek(0);
     }
 
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek(int $offset, int $whence = SEEK_SET): void
     {
         throw new \RuntimeException('Cannot seek a PumpStream');
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return false;
     }
 
-    public function write($string)
+    public function write(string $string): int
     {
         throw new \RuntimeException('Cannot write to a PumpStream');
     }
 
-    public function isReadable()
+    public function isReadable(): bool
     {
         return true;
     }
 
-    public function read($length)
+    public function read(int $length): string
     {
         $data = $this->buffer->read($length);
         $readLen = strlen($data);
@@ -138,7 +138,7 @@ class PumpStream implements StreamInterface
         return $data;
     }
 
-    public function getContents()
+    public function getContents(): string
     {
         $result = '';
         while (!$this->eof()) {
@@ -148,13 +148,13 @@ class PumpStream implements StreamInterface
         return $result;
     }
 
-    public function getMetadata($key = null)
+    public function getMetadata(?string $key = null)
     {
         if (!$key) {
             return $this->metadata;
         }
 
-        return isset($this->metadata[$key]) ? $this->metadata[$key] : null;
+        return $this->metadata[$key] ?? null;
     }
 
     private function pump($length)

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/Psr7/Request.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/Psr7/Request.php
@@ -2,13 +2,14 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 
 namespace WebDevStudios\WPSWA\Algolia\AlgoliaSearch\Http\Psr7;
 
 use InvalidArgumentException;
+use WebDevStudios\WPSWA\Psr\Http\Message\MessageInterface;
 use WebDevStudios\WPSWA\Psr\Http\Message\RequestInterface;
 use WebDevStudios\WPSWA\Psr\Http\Message\StreamInterface;
 use WebDevStudios\WPSWA\Psr\Http\Message\UriInterface;
@@ -76,7 +77,7 @@ class Request implements RequestInterface
     /**
      * @return string|null
      */
-    public function getRequestTarget()
+    public function getRequestTarget(): string
     {
         if (null !== $this->requestTarget) {
             return $this->requestTarget;
@@ -96,7 +97,7 @@ class Request implements RequestInterface
     /**
      * @return Request
      */
-    public function withRequestTarget($requestTarget)
+    public function withRequestTarget($requestTarget): RequestInterface
     {
         if (preg_match('#\s#', $requestTarget)) {
             throw new InvalidArgumentException('Invalid request target provided; cannot contain whitespace');
@@ -108,10 +109,7 @@ class Request implements RequestInterface
         return $new;
     }
 
-    /**
-     * @return string
-     */
-    public function getMethod()
+    public function getMethod(): string
     {
         return $this->method;
     }
@@ -119,7 +117,7 @@ class Request implements RequestInterface
     /**
      * @return Request
      */
-    public function withMethod($method)
+    public function withMethod(string $method): RequestInterface
     {
         $new = clone $this;
         $new->method = strtoupper($method);
@@ -130,7 +128,7 @@ class Request implements RequestInterface
     /**
      * @return Uri|UriInterface|string
      */
-    public function getUri()
+    public function getUri(): UriInterface
     {
         return $this->uri;
     }
@@ -138,7 +136,7 @@ class Request implements RequestInterface
     /**
      * @return Request
      */
-    public function withUri(UriInterface $uri, $preserveHost = false)
+    public function withUri(UriInterface $uri, $preserveHost = false): RequestInterface
     {
         if ($uri === $this->uri) {
             return $this;
@@ -180,10 +178,7 @@ class Request implements RequestInterface
         $this->headers = [$header => [$host]] + $this->headers;
     }
 
-    /**
-     * @return string
-     */
-    public function getProtocolVersion()
+    public function getProtocolVersion(): string
     {
         return $this->protocol;
     }
@@ -191,7 +186,7 @@ class Request implements RequestInterface
     /**
      * @return Request
      */
-    public function withProtocolVersion($version)
+    public function withProtocolVersion(string $version): MessageInterface
     {
         if ($this->protocol === $version) {
             return $this;
@@ -202,60 +197,48 @@ class Request implements RequestInterface
         return $new;
     }
 
-    /**
-     * @return array
-     */
-    public function getHeaders()
+    public function getHeaders(): array
     {
         return $this->headers;
     }
 
-    /**
-     * @return bool
-     */
-    public function hasHeader($header)
+    public function hasHeader(string $name): bool
     {
-        return isset($this->headerNames[strtolower($header)]);
+        return isset($this->headerNames[strtolower($name)]);
     }
 
     /**
      * @return array|mixed
      */
-    public function getHeader($header)
+    public function getHeader(string $name): array
     {
-        $header = strtolower($header);
-        if (!isset($this->headerNames[$header])) {
+        $name = strtolower($name);
+        if (!isset($this->headerNames[$name])) {
             return [];
         }
-        $header = $this->headerNames[$header];
+        $name = $this->headerNames[$name];
 
-        return $this->headers[$header];
+        return $this->headers[$name];
     }
 
-    /**
-     * @return string
-     */
-    public function getHeaderLine($header)
+    public function getHeaderLine(string $name): string
     {
-        return implode(', ', $this->getHeader($header));
+        return implode(', ', $this->getHeader($name));
     }
 
-    /**
-     * @return Request
-     */
-    public function withHeader($header, $value)
+    public function withHeader(string $name, $value): MessageInterface
     {
         if (!is_array($value)) {
             $value = [$value];
         }
         $value = $this->trimHeaderValues($value);
-        $normalized = strtolower($header);
+        $normalized = strtolower($name);
         $new = clone $this;
         if (isset($new->headerNames[$normalized])) {
             unset($new->headers[$new->headerNames[$normalized]]);
         }
-        $new->headerNames[$normalized] = $header;
-        $new->headers[$header] = $value;
+        $new->headerNames[$normalized] = $name;
+        $new->headers[$name] = $value;
 
         return $new;
     }
@@ -263,20 +246,20 @@ class Request implements RequestInterface
     /**
      * @return Request
      */
-    public function withAddedHeader($header, $value)
+    public function withAddedHeader(string $name, $value): MessageInterface
     {
         if (!is_array($value)) {
             $value = [$value];
         }
         $value = $this->trimHeaderValues($value);
-        $normalized = strtolower($header);
+        $normalized = strtolower($name);
         $new = clone $this;
         if (isset($new->headerNames[$normalized])) {
-            $header = $this->headerNames[$normalized];
-            $new->headers[$header] = array_merge($this->headers[$header], $value);
+            $name = $this->headerNames[$normalized];
+            $new->headers[$name] = array_merge($this->headers[$name], $value);
         } else {
-            $new->headerNames[$normalized] = $header;
-            $new->headers[$header] = $value;
+            $new->headerNames[$normalized] = $name;
+            $new->headers[$name] = $value;
         }
 
         return $new;
@@ -285,15 +268,15 @@ class Request implements RequestInterface
     /**
      * @return Request
      */
-    public function withoutHeader($header)
+    public function withoutHeader(string $name): MessageInterface
     {
-        $normalized = strtolower($header);
+        $normalized = strtolower($name);
         if (!isset($this->headerNames[$normalized])) {
             return $this;
         }
-        $header = $this->headerNames[$normalized];
+        $name = $this->headerNames[$normalized];
         $new = clone $this;
-        unset($new->headers[$header], $new->headerNames[$normalized]);
+        unset($new->headers[$name], $new->headerNames[$normalized]);
 
         return $new;
     }
@@ -301,7 +284,7 @@ class Request implements RequestInterface
     /**
      * @return PumpStream|Stream|StreamInterface
      */
-    public function getBody()
+    public function getBody(): StreamInterface
     {
         if (!$this->stream) {
             $this->stream = stream_for('');
@@ -313,7 +296,7 @@ class Request implements RequestInterface
     /**
      * @return Request
      */
-    public function withBody(StreamInterface $body)
+    public function withBody(StreamInterface $body): MessageInterface
     {
         if ($body === $this->stream) {
             return $this;

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/Psr7/Response.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/Psr7/Response.php
@@ -2,12 +2,13 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 
 namespace WebDevStudios\WPSWA\Algolia\AlgoliaSearch\Http\Psr7;
 
+use WebDevStudios\WPSWA\Psr\Http\Message\MessageInterface;
 use WebDevStudios\WPSWA\Psr\Http\Message\ResponseInterface;
 use WebDevStudios\WPSWA\Psr\Http\Message\StreamInterface;
 
@@ -131,18 +132,12 @@ class Response implements ResponseInterface
         $this->protocol = $version;
     }
 
-    /**
-     * @return int
-     */
-    public function getStatusCode()
+    public function getStatusCode(): int
     {
         return $this->statusCode;
     }
 
-    /**
-     * @return string
-     */
-    public function getReasonPhrase()
+    public function getReasonPhrase(): string
     {
         return $this->reasonPhrase;
     }
@@ -150,7 +145,7 @@ class Response implements ResponseInterface
     /**
      * @return static
      */
-    public function withStatus($code, $reasonPhrase = '')
+    public function withStatus(int $code, string $reasonPhrase = ''): ResponseInterface
     {
         $new = clone $this;
         $new->statusCode = (int) $code;
@@ -162,10 +157,7 @@ class Response implements ResponseInterface
         return $new;
     }
 
-    /**
-     * @return string
-     */
-    public function getProtocolVersion()
+    public function getProtocolVersion(): string
     {
         return $this->protocol;
     }
@@ -173,7 +165,7 @@ class Response implements ResponseInterface
     /**
      * @return static
      */
-    public function withProtocolVersion($version)
+    public function withProtocolVersion(string $version): MessageInterface
     {
         if ($this->protocol === $version) {
             return $this;
@@ -185,64 +177,52 @@ class Response implements ResponseInterface
         return $new;
     }
 
-    /**
-     * @return array
-     */
-    public function getHeaders()
+    public function getHeaders(): array
     {
         return $this->headers;
     }
 
-    /**
-     * @return bool
-     */
-    public function hasHeader($header)
+    public function hasHeader(string $name): bool
     {
-        return isset($this->headerNames[strtolower($header)]);
+        return isset($this->headerNames[strtolower($name)]);
     }
 
-    /**
-     * @return array
-     */
-    public function getHeader($header)
+    public function getHeader(string $name): array
     {
-        $header = strtolower($header);
+        $name = strtolower($name);
 
-        if (!isset($this->headerNames[$header])) {
+        if (!isset($this->headerNames[$name])) {
             return [];
         }
 
-        $header = $this->headerNames[$header];
+        $name = $this->headerNames[$name];
 
-        return $this->headers[$header];
+        return $this->headers[$name];
     }
 
-    /**
-     * @return string
-     */
-    public function getHeaderLine($header)
+    public function getHeaderLine(string $name): string
     {
-        return implode(', ', $this->getHeader($header));
+        return implode(', ', $this->getHeader($name));
     }
 
     /**
      * @return static
      */
-    public function withHeader($header, $value)
+    public function withHeader(string $name, $value): MessageInterface
     {
         if (!is_array($value)) {
             $value = [$value];
         }
 
         $value = $this->trimHeaderValues($value);
-        $normalized = strtolower($header);
+        $normalized = strtolower($name);
 
         $new = clone $this;
         if (isset($new->headerNames[$normalized])) {
             unset($new->headers[$new->headerNames[$normalized]]);
         }
-        $new->headerNames[$normalized] = $header;
-        $new->headers[$header] = $value;
+        $new->headerNames[$normalized] = $name;
+        $new->headers[$name] = $value;
 
         return $new;
     }
@@ -250,22 +230,22 @@ class Response implements ResponseInterface
     /**
      * @return static
      */
-    public function withAddedHeader($header, $value)
+    public function withAddedHeader(string $name, $value): MessageInterface
     {
         if (!is_array($value)) {
             $value = [$value];
         }
 
         $value = $this->trimHeaderValues($value);
-        $normalized = strtolower($header);
+        $normalized = strtolower($name);
 
         $new = clone $this;
         if (isset($new->headerNames[$normalized])) {
-            $header = $this->headerNames[$normalized];
-            $new->headers[$header] = array_merge($this->headers[$header], $value);
+            $name = $this->headerNames[$normalized];
+            $new->headers[$name] = array_merge($this->headers[$name], $value);
         } else {
-            $new->headerNames[$normalized] = $header;
-            $new->headers[$header] = $value;
+            $new->headerNames[$normalized] = $name;
+            $new->headers[$name] = $value;
         }
 
         return $new;
@@ -274,26 +254,23 @@ class Response implements ResponseInterface
     /**
      * @return static
      */
-    public function withoutHeader($header)
+    public function withoutHeader(string $name): MessageInterface
     {
-        $normalized = strtolower($header);
+        $normalized = strtolower($name);
 
         if (!isset($this->headerNames[$normalized])) {
             return $this;
         }
 
-        $header = $this->headerNames[$normalized];
+        $name = $this->headerNames[$normalized];
 
         $new = clone $this;
-        unset($new->headers[$header], $new->headerNames[$normalized]);
+        unset($new->headers[$name], $new->headerNames[$normalized]);
 
         return $new;
     }
 
-    /**
-     * @return \StreamInterface
-     */
-    public function getBody()
+    public function getBody(): StreamInterface
     {
         if (!$this->stream) {
             $this->stream = stream_for('');
@@ -305,7 +282,7 @@ class Response implements ResponseInterface
     /**
      * @return static
      */
-    public function withBody(StreamInterface $body)
+    public function withBody(StreamInterface $body): MessageInterface
     {
         if ($body === $this->stream) {
             return $this;

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/Psr7/Stream.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/Psr7/Stream.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 
@@ -91,7 +91,7 @@ class Stream implements StreamInterface
         $this->close();
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         try {
             $this->seek(0);
@@ -102,10 +102,7 @@ class Stream implements StreamInterface
         }
     }
 
-    /**
-     * @return string
-     */
-    public function getContents()
+    public function getContents(): string
     {
         if (!isset($this->stream)) {
             throw new \RuntimeException('Stream is detached');
@@ -120,10 +117,7 @@ class Stream implements StreamInterface
         return $contents;
     }
 
-    /**
-     * @return void
-     */
-    public function close()
+    public function close(): void
     {
         if (isset($this->stream)) {
             if (is_resource($this->stream)) {
@@ -153,7 +147,7 @@ class Stream implements StreamInterface
     /**
      * @return mixed|null
      */
-    public function getSize()
+    public function getSize(): ?int
     {
         if (null !== $this->size) {
             return $this->size;
@@ -178,18 +172,12 @@ class Stream implements StreamInterface
         return null;
     }
 
-    /**
-     * @return bool
-     */
-    public function isReadable()
+    public function isReadable(): bool
     {
         return $this->readable;
     }
 
-    /**
-     * @return bool
-     */
-    public function isWritable()
+    public function isWritable(): bool
     {
         return $this->writable;
     }
@@ -197,15 +185,12 @@ class Stream implements StreamInterface
     /**
      * @return bool|mixed
      */
-    public function isSeekable()
+    public function isSeekable(): bool
     {
         return $this->seekable;
     }
 
-    /**
-     * @return bool
-     */
-    public function eof()
+    public function eof(): bool
     {
         if (!isset($this->stream)) {
             throw new \RuntimeException('Stream is detached');
@@ -214,10 +199,7 @@ class Stream implements StreamInterface
         return feof($this->stream);
     }
 
-    /**
-     * @return int
-     */
-    public function tell()
+    public function tell(): int
     {
         if (!isset($this->stream)) {
             throw new \RuntimeException('Stream is detached');
@@ -232,18 +214,12 @@ class Stream implements StreamInterface
         return $result;
     }
 
-    /**
-     * @return void
-     */
-    public function rewind()
+    public function rewind(): void
     {
         $this->seek(0);
     }
 
-    /**
-     * @return void
-     */
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek(int $offset, int $whence = SEEK_SET): void
     {
         if (!isset($this->stream)) {
             throw new \RuntimeException('Stream is detached');
@@ -256,10 +232,7 @@ class Stream implements StreamInterface
         }
     }
 
-    /**
-     * @return string
-     */
-    public function read($length)
+    public function read(int $length): string
     {
         if (!isset($this->stream)) {
             throw new \RuntimeException('Stream is detached');
@@ -283,10 +256,7 @@ class Stream implements StreamInterface
         return $string;
     }
 
-    /**
-     * @return int
-     */
-    public function write($string)
+    public function write(string $string): int
     {
         if (!isset($this->stream)) {
             throw new \RuntimeException('Stream is detached');
@@ -309,7 +279,7 @@ class Stream implements StreamInterface
     /**
      * @return array|mixed|null
      */
-    public function getMetadata($key = null)
+    public function getMetadata(?string $key = null)
     {
         if (!isset($this->stream)) {
             return $key ? null : [];
@@ -321,6 +291,6 @@ class Stream implements StreamInterface
 
         $meta = stream_get_meta_data($this->stream);
 
-        return isset($meta[$key]) ? $meta[$key] : null;
+        return $meta[$key] ?? null;
     }
 }

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/Psr7/Uri.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/Psr7/Uri.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 
@@ -87,7 +87,7 @@ class Uri implements UriInterface
         }
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return self::composeComponents(
             $this->scheme,
@@ -251,7 +251,7 @@ class Uri implements UriInterface
      *
      * @see https://tools.ietf.org/html/rfc3986#section-4.4
      */
-    public static function isSameDocumentReference(UriInterface $uri, UriInterface $base = null)
+    public static function isSameDocumentReference(UriInterface $uri, ?UriInterface $base = null)
     {
         if (null !== $base) {
             $uri = UriResolver::resolve($base, $uri);
@@ -390,18 +390,12 @@ class Uri implements UriInterface
         return $uri;
     }
 
-    /**
-     * @return string
-     */
-    public function getScheme()
+    public function getScheme(): string
     {
         return $this->scheme;
     }
 
-    /**
-     * @return string
-     */
-    public function getAuthority()
+    public function getAuthority(): string
     {
         $authority = $this->host;
         if ('' !== $this->userInfo) {
@@ -415,50 +409,32 @@ class Uri implements UriInterface
         return $authority;
     }
 
-    /**
-     * @return string
-     */
-    public function getUserInfo()
+    public function getUserInfo(): string
     {
         return $this->userInfo;
     }
 
-    /**
-     * @return string
-     */
-    public function getHost()
+    public function getHost(): string
     {
         return $this->host;
     }
 
-    /**
-     * @return int|null
-     */
-    public function getPort()
+    public function getPort(): ?int
     {
         return $this->port;
     }
 
-    /**
-     * @return string
-     */
-    public function getPath()
+    public function getPath(): string
     {
         return $this->path;
     }
 
-    /**
-     * @return string
-     */
-    public function getQuery()
+    public function getQuery(): string
     {
         return $this->query;
     }
 
-    /**
-     * @return string
-     */
-    public function getFragment()
+    public function getFragment(): string
     {
         return $this->fragment;
     }
@@ -466,7 +442,7 @@ class Uri implements UriInterface
     /**
      * @return Uri
      */
-    public function withScheme($scheme)
+    public function withScheme(string $scheme): UriInterface
     {
         $scheme = $this->filterScheme($scheme);
 
@@ -485,7 +461,7 @@ class Uri implements UriInterface
     /**
      * @return Uri
      */
-    public function withUserInfo($user, $password = null)
+    public function withUserInfo(string $user, ?string $password = null): UriInterface
     {
         $info = $user;
         if ('' != $password) {
@@ -506,7 +482,7 @@ class Uri implements UriInterface
     /**
      * @return Uri
      */
-    public function withHost($host)
+    public function withHost(string $host): UriInterface
     {
         $host = $this->filterHost($host);
 
@@ -524,7 +500,7 @@ class Uri implements UriInterface
     /**
      * @return Uri
      */
-    public function withPort($port)
+    public function withPort(?int $port): UriInterface
     {
         $port = $this->filterPort($port);
 
@@ -543,7 +519,7 @@ class Uri implements UriInterface
     /**
      * @return Uri
      */
-    public function withPath($path)
+    public function withPath(string $path): UriInterface
     {
         $path = $this->filterPath($path);
 
@@ -561,7 +537,7 @@ class Uri implements UriInterface
     /**
      * @return Uri
      */
-    public function withQuery($query)
+    public function withQuery(string $query): UriInterface
     {
         $query = $this->filterQueryAndFragment($query);
 
@@ -578,7 +554,7 @@ class Uri implements UriInterface
     /**
      * @return Uri
      */
-    public function withFragment($fragment)
+    public function withFragment(string $fragment): UriInterface
     {
         $fragment = $this->filterQueryAndFragment($fragment);
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/Psr7/UriResolver.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/Psr7/UriResolver.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/Psr7/functions.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/Psr7/functions.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Insights/UserInsightsClient.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Insights/UserInsightsClient.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/InsightsClient.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/InsightsClient.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Iterators/AbstractAlgoliaIterator.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Iterators/AbstractAlgoliaIterator.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Iterators/ObjectIterator.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Iterators/ObjectIterator.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Iterators/RuleIterator.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Iterators/RuleIterator.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Iterators/SynonymIterator.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Iterators/SynonymIterator.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Log/DebugLogger.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Log/DebugLogger.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/PersonalizationClient.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/PersonalizationClient.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/PlacesClient.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/PlacesClient.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/RecommendClient.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/RecommendClient.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/RecommendationClient.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/RecommendationClient.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/RequestOptions/RequestOptions.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/RequestOptions/RequestOptions.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/RequestOptions/RequestOptionsFactory.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/RequestOptions/RequestOptionsFactory.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Response/AbstractResponse.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Response/AbstractResponse.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Response/AddApiKeyResponse.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Response/AddApiKeyResponse.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Response/BatchIndexingResponse.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Response/BatchIndexingResponse.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Response/DeleteApiKeyResponse.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Response/DeleteApiKeyResponse.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Response/DictionaryResponse.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Response/DictionaryResponse.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Response/IndexingResponse.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Response/IndexingResponse.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Response/MultiResponse.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Response/MultiResponse.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Response/MultipleIndexBatchIndexingResponse.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Response/MultipleIndexBatchIndexingResponse.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Response/NullResponse.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Response/NullResponse.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Response/RestoreApiKeyResponse.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Response/RestoreApiKeyResponse.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Response/UpdateApiKeyResponse.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Response/UpdateApiKeyResponse.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/RetryStrategy/ApiWrapper.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/RetryStrategy/ApiWrapper.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 
@@ -63,8 +63,8 @@ final class ApiWrapper implements ApiWrapperInterface
         HttpClientInterface $http,
         AbstractConfig $config,
         ClusterHosts $clusterHosts,
-        RequestOptionsFactory $RqstOptsFactory = null,
-        LoggerInterface $logger = null
+        ?RequestOptionsFactory $RqstOptsFactory = null,
+        ?LoggerInterface $logger = null
     ) {
         $this->http = $http;
         $this->config = $config;

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/RetryStrategy/ApiWrapperInterface.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/RetryStrategy/ApiWrapperInterface.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/RetryStrategy/ClusterHosts.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/RetryStrategy/ClusterHosts.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/RetryStrategy/Host.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/RetryStrategy/Host.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/RetryStrategy/HostCollection.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/RetryStrategy/HostCollection.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/SearchClient.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/SearchClient.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/SearchIndex.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/SearchIndex.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Support/Helpers.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Support/Helpers.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 
@@ -115,7 +115,10 @@ final class Helpers
     {
         $data = \json_decode($json, $assoc, $depth);
         if (JSON_ERROR_NONE !== json_last_error()) {
-            throw new \InvalidArgumentException('json_decode error: '.json_last_error_msg());
+            throw new \InvalidArgumentException(sprintf(<<<'EXCEPTION'
+json_decode_error: %s
+input string: %s
+EXCEPTION, json_last_error_msg(), $json));
         }
 
         return $data;

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Support/UserAgent.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Support/UserAgent.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/functions.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/functions.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/psr/http-message/src/MessageInterface.php
+++ b/vendor_prefixed/psr/http-message/src/MessageInterface.php
@@ -2,9 +2,11 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
+
+declare(strict_types=1);
 
 namespace WebDevStudios\WPSWA\Psr\Http\Message;
 
@@ -44,7 +46,7 @@ interface MessageInterface
      * @param string $version HTTP protocol version
      * @return static
      */
-    public function withProtocolVersion($version);
+    public function withProtocolVersion(string $version);
 
     /**
      * Retrieves all message header values.
@@ -81,7 +83,7 @@ interface MessageInterface
      *     name using a case-insensitive string comparison. Returns false if
      *     no matching header name is found in the message.
      */
-    public function hasHeader($name);
+    public function hasHeader(string $name);
 
     /**
      * Retrieves a message header value by the given case-insensitive name.
@@ -97,7 +99,7 @@ interface MessageInterface
      *    header. If the header does not appear in the message, this method MUST
      *    return an empty array.
      */
-    public function getHeader($name);
+    public function getHeader(string $name);
 
     /**
      * Retrieves a comma-separated string of the values for a single header.
@@ -118,7 +120,7 @@ interface MessageInterface
      *    concatenated together using a comma. If the header does not appear in
      *    the message, this method MUST return an empty string.
      */
-    public function getHeaderLine($name);
+    public function getHeaderLine(string $name);
 
     /**
      * Return an instance with the provided value replacing the specified header.
@@ -135,7 +137,7 @@ interface MessageInterface
      * @return static
      * @throws \InvalidArgumentException for invalid header names or values.
      */
-    public function withHeader($name, $value);
+    public function withHeader(string $name, $value);
 
     /**
      * Return an instance with the specified header appended with the given value.
@@ -153,7 +155,7 @@ interface MessageInterface
      * @return static
      * @throws \InvalidArgumentException for invalid header names or values.
      */
-    public function withAddedHeader($name, $value);
+    public function withAddedHeader(string $name, $value);
 
     /**
      * Return an instance without the specified header.
@@ -167,7 +169,7 @@ interface MessageInterface
      * @param string $name Case-insensitive header field name to remove.
      * @return static
      */
-    public function withoutHeader($name);
+    public function withoutHeader(string $name);
 
     /**
      * Gets the body of the message.

--- a/vendor_prefixed/psr/http-message/src/RequestInterface.php
+++ b/vendor_prefixed/psr/http-message/src/RequestInterface.php
@@ -2,9 +2,11 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
+
+declare(strict_types=1);
 
 namespace WebDevStudios\WPSWA\Psr\Http\Message;
 
@@ -61,10 +63,10 @@ interface RequestInterface extends MessageInterface
      *
      * @link http://tools.ietf.org/html/rfc7230#section-5.3 (for the various
      *     request-target forms allowed in request messages)
-     * @param mixed $requestTarget
+     * @param string $requestTarget
      * @return static
      */
-    public function withRequestTarget($requestTarget);
+    public function withRequestTarget(string $requestTarget);
 
     /**
      * Retrieves the HTTP method of the request.
@@ -88,7 +90,7 @@ interface RequestInterface extends MessageInterface
      * @return static
      * @throws \InvalidArgumentException for invalid HTTP methods.
      */
-    public function withMethod($method);
+    public function withMethod(string $method);
 
     /**
      * Retrieves the URI instance.
@@ -131,5 +133,5 @@ interface RequestInterface extends MessageInterface
      * @param bool $preserveHost Preserve the original state of the Host header.
      * @return static
      */
-    public function withUri(UriInterface $uri, $preserveHost = false);
+    public function withUri(UriInterface $uri, bool $preserveHost = false);
 }

--- a/vendor_prefixed/psr/http-message/src/ResponseInterface.php
+++ b/vendor_prefixed/psr/http-message/src/ResponseInterface.php
@@ -2,9 +2,11 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
+
+declare(strict_types=1);
 
 namespace WebDevStudios\WPSWA\Psr\Http\Message;
 
@@ -55,7 +57,7 @@ interface ResponseInterface extends MessageInterface
      * @return static
      * @throws \InvalidArgumentException For invalid status code arguments.
      */
-    public function withStatus($code, $reasonPhrase = '');
+    public function withStatus(int $code, string $reasonPhrase = '');
 
     /**
      * Gets the response reason phrase associated with the status code.

--- a/vendor_prefixed/psr/http-message/src/ServerRequestInterface.php
+++ b/vendor_prefixed/psr/http-message/src/ServerRequestInterface.php
@@ -2,9 +2,11 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
+
+declare(strict_types=1);
 
 namespace WebDevStudios\WPSWA\Psr\Http\Message;
 
@@ -230,7 +232,7 @@ interface ServerRequestInterface extends RequestInterface
      * @param mixed $default Default value to return if the attribute does not exist.
      * @return mixed
      */
-    public function getAttribute($name, $default = null);
+    public function getAttribute(string $name, $default = null);
 
     /**
      * Return an instance with the specified derived request attribute.
@@ -247,7 +249,7 @@ interface ServerRequestInterface extends RequestInterface
      * @param mixed $value The value of the attribute.
      * @return static
      */
-    public function withAttribute($name, $value);
+    public function withAttribute(string $name, $value);
 
     /**
      * Return an instance that removes the specified derived request attribute.
@@ -263,5 +265,5 @@ interface ServerRequestInterface extends RequestInterface
      * @param string $name The attribute name.
      * @return static
      */
-    public function withoutAttribute($name);
+    public function withoutAttribute(string $name);
 }

--- a/vendor_prefixed/psr/http-message/src/StreamInterface.php
+++ b/vendor_prefixed/psr/http-message/src/StreamInterface.php
@@ -2,9 +2,11 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
+
+declare(strict_types=1);
 
 namespace WebDevStudios\WPSWA\Psr\Http\Message;
 
@@ -90,7 +92,7 @@ interface StreamInterface
      *     SEEK_END: Set position to end-of-stream plus offset.
      * @throws \RuntimeException on failure.
      */
-    public function seek($offset, $whence = SEEK_SET);
+    public function seek(int $offset, int $whence = SEEK_SET);
 
     /**
      * Seek to the beginning of the stream.
@@ -118,7 +120,7 @@ interface StreamInterface
      * @return int Returns the number of bytes written to the stream.
      * @throws \RuntimeException on failure.
      */
-    public function write($string);
+    public function write(string $string);
 
     /**
      * Returns whether or not the stream is readable.
@@ -137,7 +139,7 @@ interface StreamInterface
      *     if no bytes are available.
      * @throws \RuntimeException if an error occurs.
      */
-    public function read($length);
+    public function read(int $length);
 
     /**
      * Returns the remaining contents in a string
@@ -155,10 +157,10 @@ interface StreamInterface
      * stream_get_meta_data() function.
      *
      * @link http://php.net/manual/en/function.stream-get-meta-data.php
-     * @param string $key Specific metadata to retrieve.
+     * @param string|null $key Specific metadata to retrieve.
      * @return array|mixed|null Returns an associative array if no key is
      *     provided. Returns a specific key value if a key is provided and the
      *     value is found, or null if the key is not found.
      */
-    public function getMetadata($key = null);
+    public function getMetadata(?string $key = null);
 }

--- a/vendor_prefixed/psr/http-message/src/UploadedFileInterface.php
+++ b/vendor_prefixed/psr/http-message/src/UploadedFileInterface.php
@@ -2,9 +2,11 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
+
+declare(strict_types=1);
 
 namespace WebDevStudios\WPSWA\Psr\Http\Message;
 
@@ -68,7 +70,7 @@ interface UploadedFileInterface
      * @throws \RuntimeException on any error during the move operation, or on
      *     the second or subsequent call to the method.
      */
-    public function moveTo($targetPath);
+    public function moveTo(string $targetPath);
     
     /**
      * Retrieve the file size.

--- a/vendor_prefixed/psr/http-message/src/UriInterface.php
+++ b/vendor_prefixed/psr/http-message/src/UriInterface.php
@@ -2,9 +2,12 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
+
+declare(strict_types=1);
+
 namespace WebDevStudios\WPSWA\Psr\Http\Message;
 
 /**
@@ -194,7 +197,7 @@ interface UriInterface
      * @return static A new instance with the specified scheme.
      * @throws \InvalidArgumentException for invalid or unsupported schemes.
      */
-    public function withScheme($scheme);
+    public function withScheme(string $scheme);
 
     /**
      * Return an instance with the specified user information.
@@ -210,7 +213,7 @@ interface UriInterface
      * @param null|string $password The password associated with $user.
      * @return static A new instance with the specified user information.
      */
-    public function withUserInfo($user, $password = null);
+    public function withUserInfo(string $user, ?string $password = null);
 
     /**
      * Return an instance with the specified host.
@@ -224,7 +227,7 @@ interface UriInterface
      * @return static A new instance with the specified host.
      * @throws \InvalidArgumentException for invalid hostnames.
      */
-    public function withHost($host);
+    public function withHost(string $host);
 
     /**
      * Return an instance with the specified port.
@@ -243,7 +246,7 @@ interface UriInterface
      * @return static A new instance with the specified port.
      * @throws \InvalidArgumentException for invalid ports.
      */
-    public function withPort($port);
+    public function withPort(?int $port);
 
     /**
      * Return an instance with the specified path.
@@ -267,7 +270,7 @@ interface UriInterface
      * @return static A new instance with the specified path.
      * @throws \InvalidArgumentException for invalid paths.
      */
-    public function withPath($path);
+    public function withPath(string $path);
 
     /**
      * Return an instance with the specified query string.
@@ -284,7 +287,7 @@ interface UriInterface
      * @return static A new instance with the specified query string.
      * @throws \InvalidArgumentException for invalid query strings.
      */
-    public function withQuery($query);
+    public function withQuery(string $query);
 
     /**
      * Return an instance with the specified URI fragment.
@@ -300,7 +303,7 @@ interface UriInterface
      * @param string $fragment The fragment to use with the new instance.
      * @return static A new instance with the specified fragment.
      */
-    public function withFragment($fragment);
+    public function withFragment(string $fragment);
 
     /**
      * Return the string representation as a URI reference.

--- a/vendor_prefixed/psr/log/Psr/Log/AbstractLogger.php
+++ b/vendor_prefixed/psr/log/Psr/Log/AbstractLogger.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/psr/log/Psr/Log/InvalidArgumentException.php
+++ b/vendor_prefixed/psr/log/Psr/Log/InvalidArgumentException.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/psr/log/Psr/Log/LogLevel.php
+++ b/vendor_prefixed/psr/log/Psr/Log/LogLevel.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/psr/log/Psr/Log/LoggerAwareInterface.php
+++ b/vendor_prefixed/psr/log/Psr/Log/LoggerAwareInterface.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/psr/log/Psr/Log/LoggerAwareTrait.php
+++ b/vendor_prefixed/psr/log/Psr/Log/LoggerAwareTrait.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/psr/log/Psr/Log/LoggerInterface.php
+++ b/vendor_prefixed/psr/log/Psr/Log/LoggerInterface.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/psr/log/Psr/Log/LoggerTrait.php
+++ b/vendor_prefixed/psr/log/Psr/Log/LoggerTrait.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/psr/log/Psr/Log/NullLogger.php
+++ b/vendor_prefixed/psr/log/Psr/Log/NullLogger.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/psr/log/Psr/Log/Test/DummyTest.php
+++ b/vendor_prefixed/psr/log/Psr/Log/Test/DummyTest.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/psr/log/Psr/Log/Test/LoggerInterfaceTest.php
+++ b/vendor_prefixed/psr/log/Psr/Log/Test/LoggerInterfaceTest.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/psr/log/Psr/Log/Test/TestLogger.php
+++ b/vendor_prefixed/psr/log/Psr/Log/Test/TestLogger.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/psr/simple-cache/src/CacheException.php
+++ b/vendor_prefixed/psr/simple-cache/src/CacheException.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/psr/simple-cache/src/CacheInterface.php
+++ b/vendor_prefixed/psr/simple-cache/src/CacheInterface.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 

--- a/vendor_prefixed/psr/simple-cache/src/InvalidArgumentException.php
+++ b/vendor_prefixed/psr/simple-cache/src/InvalidArgumentException.php
@@ -2,7 +2,7 @@
 /**
  * @license MIT
  *
- * Modified by WebDevStudios on 23-February-2023 using Strauss.
+ * Modified by WebDevStudios on 01-July-2025 using Strauss.
  * @see https://github.com/BrianHenryIE/strauss
  */
 


### PR DESCRIPTION
This PR upgrades our version of the Algolia PHP client to the latest available to us until we want to move to version 4.

Changes in 3.4.2 handle some PHP8 notices/warnings/deprecation notices.