### PR TITLE
allow for overriding of early return for FSE based themes.

### DIFF
--- a/includes/class-algolia-compatibility.php
+++ b/includes/class-algolia-compatibility.php
@@ -41,6 +41,7 @@ class Algolia_Compatibility {
 		add_action( 'algolia_after_get_records', array( $this, 'wpml_switch_back_language' ) );
 		add_action( 'algolia_excluded_post_types', [ $this, 'woocommerce_post_types' ] );
 		add_action( 'algolia_excluded_taxonomies', [ $this, 'woocommerce_internal_taxonomies' ] );
+		add_filter( 'algolia_is_block_theme', [ $this, 'maybe_block_theme' ] );
 	}
 
 	/**
@@ -173,5 +174,15 @@ class Algolia_Compatibility {
 		$taxonomies[] = 'product_shipping_class';
 
 		return $taxonomies;
+	}
+
+	/**
+	 * Return whether or not the current theme is block based.
+	 *
+	 * @since NEXT
+	 * @return bool
+	 */
+	public function maybe_block_theme() {
+		return wp_is_block_theme();
 	}
 }

--- a/includes/class-algolia-compatibility.php
+++ b/includes/class-algolia-compatibility.php
@@ -179,10 +179,15 @@ class Algolia_Compatibility {
 	/**
 	 * Return whether or not the current theme is block based.
 	 *
-	 * @since NEXT
+	 * @since 2.10.3
 	 * @return bool
 	 */
-	public function maybe_block_theme() {
+	public function maybe_block_theme( $maybe_block_theme ) {
+		// return early if it has already been determined.
+		if ( true === $maybe_block_theme ) {
+			return $maybe_block_theme;
+		}
+
 		return wp_is_block_theme();
 	}
 }

--- a/includes/class-algolia-template-loader.php
+++ b/includes/class-algolia-template-loader.php
@@ -39,7 +39,7 @@ class Algolia_Template_Loader {
 		if (
 			! $this->should_load_autocomplete() &&
 			! $settings->should_override_search_with_instantsearch() &&
-			! apply_filters( 'algolia_is_fse_theme', false )
+			! apply_filters( 'algolia_is_block_theme', false )
 		) {
 			return;
 		}

--- a/includes/class-algolia-template-loader.php
+++ b/includes/class-algolia-template-loader.php
@@ -36,7 +36,11 @@ class Algolia_Template_Loader {
 		$this->plugin = $plugin;
 
 		$settings = $this->plugin->get_settings();
-		if ( ! $this->should_load_autocomplete() && ! $settings->should_override_search_with_instantsearch() ) {
+		if (
+			! $this->should_load_autocomplete() &&
+			! $settings->should_override_search_with_instantsearch() &&
+			! apply_filters( 'algolia_is_fse_theme', false )
+		) {
 			return;
 		}
 


### PR DESCRIPTION
This PR adds in a new boolean filter to allow for still loading frontend algolia config for full site editor implementations of Autocomplete or Instantsearch.

This amends changes from version 2.10.x where we prevented loading these details if neither of our template php file versions were getting used on the frontend.

It also includes a new compatibility callback to try and help automate things.