### PR TITLE
Feature/430 term post early return

### DIFF
--- a/includes/watchers/class-algolia-term-changes-watcher.php
+++ b/includes/watchers/class-algolia-term-changes-watcher.php
@@ -104,6 +104,13 @@ class Algolia_Term_Changes_Watcher implements Algolia_Changes_Watcher {
 			return;
 		}
 
+		/**
+		 * This filters a cap of how many posts to fetch for the updated term, to update their algolia records.
+		 *
+		 * @since NEXT
+		 *
+		 * @param int $value Amount of posts to update.
+		 */
 		$limit = apply_filters( 'algolia_term_update_post_limit', 50 );
 
 		$args = [
@@ -281,6 +288,12 @@ class Algolia_Term_Changes_Watcher implements Algolia_Changes_Watcher {
 		$this->sync_item( $object_id );
 	}
 
+	/**
+	 * Conditionally set an admin notice about maybe bulk re-indexing to update
+	 * Algolia post records that have this term.
+	 *
+	 * @since NEXT
+	 */
 	public function large_count_notice() {
 		global $current_screen;
 
@@ -296,6 +309,7 @@ class Algolia_Term_Changes_Watcher implements Algolia_Changes_Watcher {
 			return;
 		}
 
+		// This filter is documented in includes/watchers/class-algolia-term-changes-watcher.php
 		$limit = apply_filters( 'algolia_term_update_post_limit', 50 );
 		if ( $term->count > absint( $limit ) ) {
 			wp_admin_notice(

--- a/includes/watchers/class-algolia-term-changes-watcher.php
+++ b/includes/watchers/class-algolia-term-changes-watcher.php
@@ -86,6 +86,22 @@ class Algolia_Term_Changes_Watcher implements Algolia_Changes_Watcher {
 		if ( ! $term || ! $this->index->supports( $term ) ) {
 			return;
 		}
+
+		/**
+		 * Filters whether or not to update posts with the edited term.
+		 *
+		 * @since NEXT
+		 *
+		 * @param bool   $value    Whether or not to sync posts with this term.
+		 * @param int    $term_id  The current term to be updated.
+		 * @param int    $tt_id    The term taxonomy ID.
+		 * @param string $taxonomy The taxonomy slug.
+		 */
+		$should_sync_term_posts = apply_filters( 'algolia_should_sync_term_posts', true, $term_id, $tt_id, $taxonomy );
+		if ( ! $should_sync_term_posts ) {
+			return;
+		}
+
 		$args = [
 			'posts_per_page' => -1,
 			'tax_query'      => [

--- a/includes/watchers/class-algolia-term-changes-watcher.php
+++ b/includes/watchers/class-algolia-term-changes-watcher.php
@@ -104,8 +104,10 @@ class Algolia_Term_Changes_Watcher implements Algolia_Changes_Watcher {
 			return;
 		}
 
+		$limit = apply_filters( 'algolia_term_update_post_limit', 50 );
+
 		$args = [
-			'posts_per_page' => -1,
+			'posts_per_page' => $limit,
 			'tax_query'      => [
 				[
 					'taxonomy' => $taxonomy,

--- a/includes/watchers/class-algolia-term-changes-watcher.php
+++ b/includes/watchers/class-algolia-term-changes-watcher.php
@@ -92,7 +92,7 @@ class Algolia_Term_Changes_Watcher implements Algolia_Changes_Watcher {
 		/**
 		 * Filters whether or not to update posts with the edited term.
 		 *
-		 * @since NEXT
+		 * @since 2.11.3
 		 *
 		 * @param bool   $value    Whether or not to sync posts with this term.
 		 * @param int    $term_id  The current term to be updated.
@@ -107,7 +107,7 @@ class Algolia_Term_Changes_Watcher implements Algolia_Changes_Watcher {
 		/**
 		 * This filters a cap of how many posts to fetch for the updated term, to update their algolia records.
 		 *
-		 * @since NEXT
+		 * @since 2.11.3
 		 *
 		 * @param int $value Amount of posts to update.
 		 */
@@ -292,7 +292,7 @@ class Algolia_Term_Changes_Watcher implements Algolia_Changes_Watcher {
 	 * Conditionally set an admin notice about maybe bulk re-indexing to update
 	 * Algolia post records that have this term.
 	 *
-	 * @since NEXT
+	 * @since 2.11.3
 	 */
 	public function large_count_notice() {
 		global $current_screen;


### PR DESCRIPTION
NEEDS FEATURE BRANCH

This PR adds a filter to allow early return before any re-indexing occurs, but also a hard limit at 50 posts before adding an admin notice about bulk re-indexing to handle the rest.