### PR TITLE
Fix: Explicit nullable typehints and update PHPCompatibility range for PHP 8.4:

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -105,6 +105,6 @@
 	<rule ref="PHPCompatibilityWP"/>
 
 	<!-- WPSWA currently supports PHP 7.4+. -->
-	<config name="testVersion" value="7.4-"/>
+	<config name="testVersion" value="7.4-8.4"/>
 
 </ruleset>

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/GuzzleHttpClient.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/GuzzleHttpClient.php
@@ -20,7 +20,7 @@ final class GuzzleHttpClient implements HttpClientInterface
 {
     private $client;
 
-    public function __construct(GuzzleClient $client = null)
+    public function __construct(?GuzzleClient $client = null)
     {
         $this->client = $client ?: static::buildClient();
     }

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/Psr7/Uri.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/Http/Psr7/Uri.php
@@ -251,7 +251,7 @@ class Uri implements UriInterface
      *
      * @see https://tools.ietf.org/html/rfc3986#section-4.4
      */
-    public static function isSameDocumentReference(UriInterface $uri, UriInterface $base = null)
+    public static function isSameDocumentReference(UriInterface $uri, ?UriInterface $base = null)
     {
         if (null !== $base) {
             $uri = UriResolver::resolve($base, $uri);

--- a/vendor_prefixed/algolia/algoliasearch-client-php/src/RetryStrategy/ApiWrapper.php
+++ b/vendor_prefixed/algolia/algoliasearch-client-php/src/RetryStrategy/ApiWrapper.php
@@ -63,8 +63,8 @@ final class ApiWrapper implements ApiWrapperInterface
         HttpClientInterface $http,
         AbstractConfig $config,
         ClusterHosts $clusterHosts,
-        RequestOptionsFactory $RqstOptsFactory = null,
-        LoggerInterface $logger = null
+        ?RequestOptionsFactory $RqstOptsFactory = null,
+        ?LoggerInterface $logger = null
     ) {
         $this->http = $http;
         $this->config = $config;


### PR DESCRIPTION
* Add explicit nullable types in Algolia client wrappers to silence PHP 8.4 implicit-null deprecations.
* Update PHPCS PHPCompatibility testVersion to scan 7.4 through 8.4 while keeping minimum support at 7.4.
* Note: minimum remains 7.4; verified compatibility extends through 8.4.