### PR TITLE
533 ajax response alerts

### DIFF
--- a/includes/admin/class-algolia-admin.php
+++ b/includes/admin/class-algolia-admin.php
@@ -280,14 +280,15 @@ class Algolia_Admin {
 			}
 			ob_end_clean();
 
-			$response = array(
+			$response = [
+				'currentPage'     => $page,
 				'totalPagesCount' => $total_pages,
 				'finished'        => $page >= $total_pages,
-			);
+			];
 
-			wp_send_json( $response );
+			wp_send_json_success( $response, 200 );
 		} catch ( Exception $exception ) {
-			wp_send_json_error( array( 'message' => $exception->getMessage() ) );
+			wp_send_json_error( [ 'message' => $exception->getMessage() ], 500 );
 		}
 	}
 

--- a/includes/admin/class-algolia-admin.php
+++ b/includes/admin/class-algolia-admin.php
@@ -324,9 +324,10 @@ class Algolia_Admin {
 			$response = array(
 				'success' => true,
 			);
-			wp_send_json( $response );
+
+			wp_send_json_success( $response, 200 );
 		} catch ( Exception $exception ) {
-			wp_send_json_error( array( 'message' => $exception->getMessage() ) );
+			wp_send_json_error( array( 'message' => $exception->getMessage() ), 500 );
 		}
 	}
 

--- a/includes/admin/class-algolia-admin.php
+++ b/includes/admin/class-algolia-admin.php
@@ -122,7 +122,11 @@ class Algolia_Admin {
 			'algolia-admin-push-settings-button',
 			'algoliaPushSettingsButton',
 			[
-				'pushBtnAlert' => esc_html__( 'Warning: Pushing settings will override the settings in the Algolia dashboard. Do you want to continue?', 'wp-search-with-algolia' ),
+				'noDataIndex'          => esc_html__( 'Clicked button has no "data-index" set.', 'wp-search-with-algolia' ),
+				'pushBtnAlert'         => esc_html__( 'Warning: Pushing settings will override the settings in the Algolia dashboard. Do you want to continue?', 'wp-search-with-algolia' ),
+				'correctlyPushed'      => esc_html__( 'Settings correctly pushed for index:', 'wp-search-with-algolia' ),
+				'errorPrefix'          => esc_html__( 'Error:', 'wp-search-with-algolia' ),
+				'exceptionErrorPrefix' => esc_html__( 'Exception error:', 'wp-search-with-algolia' ),
 			]
 		);
 

--- a/includes/admin/class-algolia-admin.php
+++ b/includes/admin/class-algolia-admin.php
@@ -121,9 +121,22 @@ class Algolia_Admin {
 		wp_localize_script(
 			'algolia-admin-push-settings-button',
 			'algoliaPushSettingsButton',
-			array(
+			[
 				'pushBtnAlert' => esc_html__( 'Warning: Pushing settings will override the settings in the Algolia dashboard. Do you want to continue?', 'wp-search-with-algolia' ),
-			)
+			]
+		);
+
+		wp_localize_script(
+			'algolia-admin-reindex-button',
+			'algoliaPushReindexButton',
+			[
+				'reindexAbort'         => esc_html__( 'If you leave now, re-indexing tasks in progress will be aborted', 'wp-search-with-algolia' ),
+				'noDataindex'          => esc_html__( 'Clicked button has no "data-index" set.', 'wp-search-with-algolia' ),
+				'processingPrefix'     => esc_html__( 'Processing, please be patient ...', 'wp-search-with-algolia' ),
+				'errorPrefix'          => esc_html__( 'Error:', 'wp-search-with-algolia' ),
+				'exceptionErrorPrefix' => esc_html__( 'Exception error:', 'wp-search-with-algolia' ),
+				'noPageCount'          => esc_html__( 'An error occurred. Unable to find a page count.', 'wp-search-with-algolia' ),
+			]
 		);
 	}
 

--- a/includes/admin/class-algolia-admin.php
+++ b/includes/admin/class-algolia-admin.php
@@ -127,6 +127,7 @@ class Algolia_Admin {
 				'correctlyPushed'      => esc_html__( 'Settings correctly pushed for index:', 'wp-search-with-algolia' ),
 				'errorPrefix'          => esc_html__( 'Error:', 'wp-search-with-algolia' ),
 				'exceptionErrorPrefix' => esc_html__( 'Exception error:', 'wp-search-with-algolia' ),
+				'genericError'         => esc_html__( 'Unknown error', 'wp-search-with-algolia' ),
 			]
 		);
 
@@ -321,9 +322,7 @@ class Algolia_Admin {
 
 			$index->push_settings();
 
-			$response = array(
-				'success' => true,
-			);
+			$response = [];
 
 			wp_send_json_success( $response, 200 );
 		} catch ( Exception $exception ) {

--- a/includes/admin/class-algolia-admin.php
+++ b/includes/admin/class-algolia-admin.php
@@ -151,7 +151,11 @@ class Algolia_Admin {
 			'algolia-admin-push-settings-button',
 			'algoliaPushSettingsButton',
 			[
-				'pushBtnAlert' => esc_html__( 'Warning: Pushing settings will override the settings in the Algolia dashboard. Do you want to continue?', 'wp-search-with-algolia' ),
+				'noDataIndex'          => esc_html__( 'Clicked button has no "data-index" set.', 'wp-search-with-algolia' ),
+				'pushBtnAlert'         => esc_html__( 'Warning: Pushing settings will override the settings in the Algolia dashboard. Do you want to continue?', 'wp-search-with-algolia' ),
+				'correctlyPushed'      => esc_html__( 'Settings correctly pushed for index:', 'wp-search-with-algolia' ),
+				'errorPrefix'          => esc_html__( 'Error:', 'wp-search-with-algolia' ),
+				'exceptionErrorPrefix' => esc_html__( 'Exception error:', 'wp-search-with-algolia' ),
 			]
 		);
 

--- a/includes/admin/class-algolia-admin.php
+++ b/includes/admin/class-algolia-admin.php
@@ -156,6 +156,7 @@ class Algolia_Admin {
 				'correctlyPushed'      => esc_html__( 'Settings correctly pushed for index:', 'wp-search-with-algolia' ),
 				'errorPrefix'          => esc_html__( 'Error:', 'wp-search-with-algolia' ),
 				'exceptionErrorPrefix' => esc_html__( 'Exception error:', 'wp-search-with-algolia' ),
+				'genericError'         => esc_html__( 'Unknown error', 'wp-search-with-algolia' ),
 			]
 		);
 
@@ -350,9 +351,7 @@ class Algolia_Admin {
 
 			$index->push_settings();
 
-			$response = array(
-				'success' => true,
-			);
+			$response = [];
 
 			wp_send_json_success( $response, 200 );
 		} catch ( Exception $exception ) {

--- a/includes/admin/class-algolia-admin.php
+++ b/includes/admin/class-algolia-admin.php
@@ -309,14 +309,15 @@ class Algolia_Admin {
 			}
 			ob_end_clean();
 
-			$response = array(
+			$response = [
+				'currentPage'     => $page,
 				'totalPagesCount' => $total_pages,
 				'finished'        => $page >= $total_pages,
-			);
+			];
 
-			wp_send_json( $response );
+			wp_send_json_success( $response, 200 );
 		} catch ( Exception $exception ) {
-			wp_send_json_error( array( 'message' => $exception->getMessage() ) );
+			wp_send_json_error( [ 'message' => $exception->getMessage() ], 500 );
 		}
 	}
 

--- a/includes/admin/class-algolia-admin.php
+++ b/includes/admin/class-algolia-admin.php
@@ -351,9 +351,7 @@ class Algolia_Admin {
 
 			$index->push_settings();
 
-			$response = [];
-
-			wp_send_json_success( $response, 200 );
+			wp_send_json_success( [], 200 );
 		} catch ( Exception $exception ) {
 			wp_send_json_error( array( 'message' => $exception->getMessage() ), 500 );
 		}

--- a/includes/admin/class-algolia-admin.php
+++ b/includes/admin/class-algolia-admin.php
@@ -153,7 +153,7 @@ class Algolia_Admin {
 			[
 				'noDataIndex'          => esc_html__( 'Clicked button has no "data-index" set.', 'wp-search-with-algolia' ),
 				'pushBtnAlert'         => esc_html__( 'Warning: Pushing settings will override the settings in the Algolia dashboard. Do you want to continue?', 'wp-search-with-algolia' ),
-				'correctlyPushed'      => esc_html__( 'Settings correctly pushed for index:', 'wp-search-with-algolia' ),
+				'successfullyPushed'   => esc_html__( 'Settings successfully pushed for index:', 'wp-search-with-algolia' ),
 				'errorPrefix'          => esc_html__( 'Error:', 'wp-search-with-algolia' ),
 				'exceptionErrorPrefix' => esc_html__( 'Exception error:', 'wp-search-with-algolia' ),
 				'genericError'         => esc_html__( 'Unknown error', 'wp-search-with-algolia' ),

--- a/includes/admin/class-algolia-admin.php
+++ b/includes/admin/class-algolia-admin.php
@@ -150,9 +150,22 @@ class Algolia_Admin {
 		wp_localize_script(
 			'algolia-admin-push-settings-button',
 			'algoliaPushSettingsButton',
-			array(
+			[
 				'pushBtnAlert' => esc_html__( 'Warning: Pushing settings will override the settings in the Algolia dashboard. Do you want to continue?', 'wp-search-with-algolia' ),
-			)
+			]
+		);
+
+		wp_localize_script(
+			'algolia-admin-reindex-button',
+			'algoliaPushReindexButton',
+			[
+				'reindexAbort'         => esc_html__( 'If you leave now, re-indexing tasks in progress will be aborted', 'wp-search-with-algolia' ),
+				'noDataindex'          => esc_html__( 'Clicked button has no "data-index" set.', 'wp-search-with-algolia' ),
+				'processingPrefix'     => esc_html__( 'Processing, please be patient ...', 'wp-search-with-algolia' ),
+				'errorPrefix'          => esc_html__( 'Error:', 'wp-search-with-algolia' ),
+				'exceptionErrorPrefix' => esc_html__( 'Exception error:', 'wp-search-with-algolia' ),
+				'noPageCount'          => esc_html__( 'An error occurred. Unable to find a page count.', 'wp-search-with-algolia' ),
+			]
 		);
 	}
 

--- a/includes/admin/class-algolia-admin.php
+++ b/includes/admin/class-algolia-admin.php
@@ -353,9 +353,10 @@ class Algolia_Admin {
 			$response = array(
 				'success' => true,
 			);
-			wp_send_json( $response );
+
+			wp_send_json_success( $response, 200 );
 		} catch ( Exception $exception ) {
-			wp_send_json_error( array( 'message' => $exception->getMessage() ) );
+			wp_send_json_error( array( 'message' => $exception->getMessage() ), 500 );
 		}
 	}
 

--- a/includes/admin/js/push-settings-button.js
+++ b/includes/admin/js/push-settings-button.js
@@ -43,10 +43,12 @@
 
 		$.post(
 			ajaxurl, data, function(response) {
-				if (typeof response.success === 'undefined') {
-					alert( 'An error occurred' );
-					enableButton( $clickedButton );
-					return;
+				if (typeof response.success !== 'undefined' && response.success === false) {
+					if (typeof response.data.message !== 'undefined') {
+						alert(algoliaPushReindexButton.errorPrefix + ' ' + response.data.message);
+						enableButton($clickedButton);
+						return;
+					}
 				}
 
 				alert(algoliaPushSettingsButton.correctlyPushed + ' ' + index );

--- a/includes/admin/js/push-settings-button.js
+++ b/includes/admin/js/push-settings-button.js
@@ -49,7 +49,7 @@
 			ajaxurl, data, function(response) {
 				if (typeof response.success !== 'undefined' && response.success === false) {
 					if (typeof response.data.message !== 'undefined') {
-						alert(algoliaPushReindexButton.errorPrefix + ' ' + response.data.message);
+						alert(algoliaPushReindexButton.genericError);
 						enableButton($clickedButton);
 						return;
 					}

--- a/includes/admin/js/push-settings-button.js
+++ b/includes/admin/js/push-settings-button.js
@@ -10,10 +10,10 @@
 	);
 
 	function handleButtonClick(e) {
-		$clickedButton = $( e.currentTarget );
-		var index      = $clickedButton.data( 'index' );
-		if ( ! index) {
-			throw new Error( 'Clicked button has no "data-index" set.' );
+		let $clickedButton = $(e.currentTarget);
+		let index = $clickedButton.data('index');
+		if (!index) {
+			throw new Error(algoliaPushSettingsButton.noDataIndex);
 		}
 
 		if ( ! window.confirm( algoliaPushSettingsButton.pushBtnAlert ) ) {
@@ -48,12 +48,12 @@
 					return;
 				}
 
-				alert( 'Settings correctly pushed for index: ' + index );
+				alert(algoliaPushSettingsButton.correctlyPushed + ' ' + index );
 				enableButton( $clickedButton );
 			}
 		).fail(
 			function(response) {
-				alert( 'An error occurred: ' + response.responseText );
+				alert(algoliaPushReindexButton.exceptionErrorPrefix + ' ' + response.responseJSON.data.message );
 				enableButton( $clickedButton );
 			}
 		);

--- a/includes/admin/js/push-settings-button.js
+++ b/includes/admin/js/push-settings-button.js
@@ -5,8 +5,12 @@
 
 	$(
 		function() {
-			let $buttons = $( '.algolia-push-settings-button' );
-			$buttons.on( 'click', handleButtonClick );
+			let buttons = document.querySelectorAll('.algolia-push-settings-button');
+			if (buttons) {
+				Array.from(buttons).forEach((button) => {
+					button.addEventListener('click', handleButtonClick);
+				});
+			}
 		}
 	);
 

--- a/includes/admin/js/push-settings-button.js
+++ b/includes/admin/js/push-settings-button.js
@@ -1,10 +1,11 @@
+'use strict';
 (function($) {
 
 	/* global algoliaPushSettingsButton */
 
 	$(
 		function() {
-			var $buttons = $( '.algolia-push-settings-button' );
+			let $buttons = $( '.algolia-push-settings-button' );
 			$buttons.on( 'click', handleButtonClick );
 		}
 	);
@@ -16,13 +17,13 @@
 			throw new Error(algoliaPushSettingsButton.noDataIndex);
 		}
 
-		if ( ! window.confirm( algoliaPushSettingsButton.pushBtnAlert ) ) {
+		if (!window.confirm(algoliaPushSettingsButton.pushBtnAlert)) {
 			return;
 		}
 
-		disableButton( $clickedButton );
+		disableButton($clickedButton);
 
-		pushSettings( $clickedButton, index );
+		pushSettings($clickedButton, index);
 	}
 
 	function disableButton($button) {
@@ -35,7 +36,7 @@
 
 	function pushSettings($clickedButton, index) {
 
-		var data = {
+		let data = {
 			'action': 'algolia_push_settings',
 			'index_id': index
 		};

--- a/includes/admin/js/push-settings-button.js
+++ b/includes/admin/js/push-settings-button.js
@@ -40,7 +40,7 @@
 
 	function pushSettings($clickedButton, index) {
 
-		let data = {
+		const data = {
 			'action': 'algolia_push_settings',
 			'index_id': index
 		};

--- a/includes/admin/js/push-settings-button.js
+++ b/includes/admin/js/push-settings-button.js
@@ -5,7 +5,7 @@
 
 	$(
 		function() {
-			let buttons = document.querySelectorAll('.algolia-push-settings-button');
+			const buttons = document.querySelectorAll('.algolia-push-settings-button');
 			if (buttons) {
 				Array.from(buttons).forEach((button) => {
 					button.addEventListener('click', handleButtonClick);

--- a/includes/admin/js/push-settings-button.js
+++ b/includes/admin/js/push-settings-button.js
@@ -55,7 +55,7 @@
 					}
 				}
 
-				alert(algoliaPushSettingsButton.correctlyPushed + ' ' + index );
+				alert(algoliaPushSettingsButton.successfullyPushed + ' ' + index );
 				enableButton( $clickedButton );
 			}
 		).fail(

--- a/includes/admin/js/push-settings-button.js
+++ b/includes/admin/js/push-settings-button.js
@@ -16,7 +16,7 @@
 
 	function handleButtonClick(e) {
 		let $clickedButton = $(e.currentTarget);
-		let index = $clickedButton.data('index');
+		const index = $clickedButton.data('index');
 		if (!index) {
 			throw new Error(algoliaPushSettingsButton.noDataIndex);
 		}

--- a/includes/admin/js/reindex-button.js
+++ b/includes/admin/js/reindex-button.js
@@ -12,7 +12,7 @@
 	$( window ).on(
 		'beforeunload', function() {
 			if (ongoing > 0) {
-				return 'If you leave now, re-indexing tasks in progress will be aborted';
+				return algoliaPushReindexButton.reindexAbort;
 			}
 		}
 	);
@@ -22,7 +22,7 @@
 		$clickedButton = $( e.currentTarget );
 		var index      = $clickedButton.data( 'index' );
 		if ( ! index) {
-			throw new Error( 'Clicked button has no "data-index" set.' );
+			throw new Error( algoliaPushReindexButton.noDataindex );
 		}
 
 		ongoing++;
@@ -35,7 +35,7 @@
 	}
 
 	function updateIndexingPourcentage($clickedButton, amount) {
-		$clickedButton.text( 'Processing, please be patient ... ' + amount + '%' );
+		$clickedButton.text(algoliaPushReindexButton.processingPrefix + ' ' + amount + '%');
 	}
 
 	function reIndex($clickedButton, index, currentPage) {
@@ -73,9 +73,9 @@
 				}
 			}
 		).fail(
-			function(response) {
-				alert( 'An error occurred: ' + response.responseText );
-				resetButton( $clickedButton );
+			function (response) {
+				alert(algoliaPushReindexButton.exceptionErrorPrefix + ' ' + response.responseJSON.data.message);
+				resetButton($clickedButton);
 			}
 		);
 	}

--- a/includes/admin/js/reindex-button.js
+++ b/includes/admin/js/reindex-button.js
@@ -3,8 +3,12 @@
 
 	$(
 		function() {
-			var $reindexButtons = $( '.algolia-reindex-button' );
-			$reindexButtons.on( 'click', handleReindexButtonClick );
+			const reindexButtons = document.querySelectorAll('.algolia-reindex-button');
+			if (reindexButtons) {
+				Array.from(reindexButtons).forEach((button) => {
+					button.addEventListener('click', handleReindexButtonClick);
+				});
+			}
 		}
 	);
 

--- a/includes/admin/js/reindex-button.js
+++ b/includes/admin/js/reindex-button.js
@@ -1,3 +1,4 @@
+'use strict';
 (function($) {
 
 	$(
@@ -7,7 +8,7 @@
 		}
 	);
 
-	var ongoing = 0;
+	let ongoing = 0;
 
 	$( window ).on(
 		'beforeunload', function() {
@@ -19,19 +20,19 @@
 
 	function handleReindexButtonClick(e) {
 
-		$clickedButton = $( e.currentTarget );
-		var index      = $clickedButton.data( 'index' );
-		if ( ! index) {
-			throw new Error( algoliaPushReindexButton.noDataindex );
+		let $clickedButton = $(e.currentTarget);
+		let index = $clickedButton.data('index');
+		if (!index) {
+			throw new Error(algoliaPushReindexButton.noDataindex);
 		}
 
 		ongoing++;
 
-		$clickedButton.attr( 'disabled', 'disabled' );
-		$clickedButton.data( 'originalText', $clickedButton.text() );
-		updateIndexingPourcentage( $clickedButton, 0 );
+		$clickedButton.attr('disabled', 'disabled');
+		$clickedButton.data('originalText', $clickedButton.text());
+		updateIndexingPourcentage($clickedButton, 0);
 
-		reIndex( $clickedButton, index );
+		reIndex($clickedButton, index);
 	}
 
 	function updateIndexingPourcentage($clickedButton, amount) {
@@ -43,7 +44,7 @@
 			currentPage = 1;
 		}
 
-		var data = {
+		let data = {
 			'action': 'algolia_re_index',
 			'index_id': index,
 			'p': currentPage
@@ -64,15 +65,15 @@
 					return;
 				}
 
-				if (response.totalPagesCount === 0) {
+				if (response.data.totalPagesCount === 0) {
 					$clickedButton.parents( '.error' ).fadeOut();
 					resetButton( $clickedButton );
 					return;
 				}
-				progress = Math.round( (currentPage / response.totalPagesCount) * 100 );
+				let progress = Math.round( (currentPage / response.data.totalPagesCount) * 100 );
 				updateIndexingPourcentage( $clickedButton, progress );
 
-				if (response.finished !== true) {
+				if (response.data.finished !== true) {
 					reIndex( $clickedButton, index, ++currentPage );
 				} else {
 					$clickedButton.parents( '.error' ).fadeOut();

--- a/includes/admin/js/reindex-button.js
+++ b/includes/admin/js/reindex-button.js
@@ -51,8 +51,15 @@
 
 		$.post(
 			ajaxurl, data, function(response) {
-				if (typeof response.totalPagesCount === 'undefined') {
-					alert( 'An error occurred' );
+				if (typeofresponse.success !== 'undefined' && response.success === false) {
+					if (typeof response.data.message !== 'undefined') {
+						alert(algoliaPushReindexButton.errorPrefix + ' ' + response.data.message);
+						resetButton($clickedButton);
+						return;
+					}
+				}
+				if (typeof response.data.totalPagesCount === 'undefined') {
+					alert(algoliaPushReindexButton.noPageCount );
 					resetButton( $clickedButton );
 					return;
 				}

--- a/includes/admin/js/reindex-button.js
+++ b/includes/admin/js/reindex-button.js
@@ -56,7 +56,7 @@
 
 		$.post(
 			ajaxurl, data, function(response) {
-				if (typeofresponse.success !== 'undefined' && response.success === false) {
+				if (typeof response.success !== 'undefined' && response.success === false) {
 					if (typeof response.data.message !== 'undefined') {
 						alert(algoliaPushReindexButton.errorPrefix + ' ' + response.data.message);
 						resetButton($clickedButton);

--- a/includes/admin/js/reindex-button.js
+++ b/includes/admin/js/reindex-button.js
@@ -25,7 +25,7 @@
 	function handleReindexButtonClick(e) {
 
 		let $clickedButton = $(e.currentTarget);
-		let index = $clickedButton.data('index');
+		const index = $clickedButton.data('index');
 		if (!index) {
 			throw new Error(algoliaPushReindexButton.noDataindex);
 		}
@@ -48,7 +48,7 @@
 			currentPage = 1;
 		}
 
-		let data = {
+		const data = {
 			'action': 'algolia_re_index',
 			'index_id': index,
 			'p': currentPage


### PR DESCRIPTION
This PR adjusts returned responses for AJAX requests around re-indexing of content as well as index settings pushes.

This should bubble up actual error messages to the triggered alerts, to help better determine issues going on at that time, instead of having site owners have to self inspect XHR responses or support log in to observe first hand.

It also somewhat converts away from jQuery, but not completely for the sake of baby steps only.