### PR TITLE
permit browse acl after recent changes for automated search api keys

### DIFF
--- a/includes/class-algolia-api.php
+++ b/includes/class-algolia-api.php
@@ -221,6 +221,10 @@ class Algolia_API {
 			unset( $scopes['listIndexes'] );
 		}
 
+		if ( isset( $scopes['browse'] ) ) {
+			unset( $scopes['browse'] );
+		}
+
 		// Short circuit ACL checks for local development.
 		if ( defined( 'WP_LOCAL_DEV' ) && WP_LOCAL_DEV ) {
 			return true;


### PR DESCRIPTION
This PR adds in a new check for known/trusted scopes coming from newly created Algolia applications.