### PR TITLE
Refresh plugin admin: branded layout, clearer copy, new Pro CTA

### DIFF
--- a/classmap.php
+++ b/classmap.php
@@ -66,6 +66,7 @@ require_once ALGOLIA_PATH . 'includes/utilities/class-algolia-update-messages.ph
 
 if ( is_admin() ) {
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin.php';
+	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin-field-helpers.php';
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin-page-settings.php';
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin-page-autocomplete.php';
 	require_once ALGOLIA_PATH . 'includes/admin/class-algolia-admin-page-native-search.php';

--- a/includes/admin/class-algolia-admin-field-helpers.php
+++ b/includes/admin/class-algolia-admin-field-helpers.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Algolia_Admin_Field_Helpers class file.
+ *
+ * Provides reusable rendering helpers for admin settings fields:
+ * - A short description plus a collapsible "Learn more" disclosure for
+ *   extended help content.
+ * - An inline notice shown when a setting is locked by a wp-config.php
+ *   constant.
+ *
+ * Used by the main Settings page and (in later phases) the Autocomplete
+ * and Search settings pages.
+ *
+ * @author  WebDevStudios <contact@webdevstudios.com>
+ * @since   2.11.0
+ *
+ * @package WebDevStudios\WPSWA
+ */
+
+/**
+ * Class Algolia_Admin_Field_Helpers
+ *
+ * @since 2.11.0
+ */
+class Algolia_Admin_Field_Helpers {
+
+	/**
+	 * Render the always-visible short description plus an optional
+	 * collapsible "Learn more" block containing extended help.
+	 *
+	 * @since 2.11.0
+	 *
+	 * @param string   $short_description   Short, one-sentence description (plain text).
+	 * @param array    $extended_paragraphs Long-form help blocks rendered in order. Each entry
+	 *                                      may be a string (rendered as a paragraph) or an
+	 *                                      array of strings (rendered as a bullet list). Limited HTML allowed.
+	 * @param string[] $bullets             Optional bullet items rendered after the paragraphs.
+	 * @param array    $doc_link {
+	 *     Optional doc link rendered at the end of the body.
+	 *
+	 *     @type string $url   Full URL.
+	 *     @type string $label Visible link text.
+	 * }
+	 * @param string   $summary_label       Optional override for the disclosure label. Defaults to "Learn more".
+	 *
+	 * @return void
+	 */
+	public static function render_field_help(
+		$short_description,
+		array $extended_paragraphs = array(),
+		array $bullets = array(),
+		array $doc_link = array(),
+		$summary_label = ''
+	) {
+		echo '<p class="description">' . esc_html( $short_description ) . '</p>';
+
+		$has_paragraphs = ! empty( $extended_paragraphs );
+		$has_bullets    = ! empty( $bullets );
+		$has_doc_link   = ! empty( $doc_link['url'] ) && ! empty( $doc_link['label'] );
+
+		if ( ! $has_paragraphs && ! $has_bullets && ! $has_doc_link ) {
+			return;
+		}
+
+		$summary = '' !== $summary_label
+			? $summary_label
+			: __( 'Learn more', 'wp-search-with-algolia' );
+
+		$allowed_html = array(
+			'a'      => array(
+				'href'   => true,
+				'target' => true,
+				'rel'    => true,
+			),
+			'strong' => array(),
+			'em'     => array(),
+			'code'   => array(),
+			'br'     => array(),
+		);
+
+		echo '<details class="algolia-field-help">';
+		echo '<summary>' . esc_html( $summary ) . '</summary>';
+		echo '<div class="algolia-field-help__body">';
+
+		foreach ( $extended_paragraphs as $entry ) {
+			if ( is_array( $entry ) ) {
+				echo '<ul>';
+				foreach ( $entry as $bullet ) {
+					echo '<li>' . wp_kses( $bullet, $allowed_html ) . '</li>';
+				}
+				echo '</ul>';
+				continue;
+			}
+			echo '<p>' . wp_kses( $entry, $allowed_html ) . '</p>';
+		}
+
+		if ( $has_bullets ) {
+			echo '<ul>';
+			foreach ( $bullets as $bullet ) {
+				echo '<li>' . wp_kses( $bullet, $allowed_html ) . '</li>';
+			}
+			echo '</ul>';
+		}
+
+		if ( $has_doc_link ) {
+			echo '<p class="algolia-field-help__doc-link"><a href="'
+				. esc_url( $doc_link['url'] )
+				. '" target="_blank" rel="noopener noreferrer">'
+				. esc_html( $doc_link['label'] )
+				. ' <span class="dashicons dashicons-external" aria-hidden="true"></span>'
+				. '<span class="screen-reader-text"> '
+				. esc_html__( '(opens in a new tab)', 'wp-search-with-algolia' )
+				. '</span>'
+				. '</a></p>';
+		}
+
+		echo '</div></details>';
+	}
+
+	/**
+	 * Render an inline notice indicating that a setting is locked by a
+	 * wp-config.php constant.
+	 *
+	 * @since 2.11.0
+	 *
+	 * @param string $constant_name The PHP constant name (e.g. ALGOLIA_APPLICATION_ID).
+	 *
+	 * @return void
+	 */
+	public static function render_constant_locked_notice( $constant_name ) {
+		$known_constants = array(
+			'ALGOLIA_APPLICATION_ID',
+			'ALGOLIA_SEARCH_API_KEY',
+			'ALGOLIA_API_KEY',
+			'ALGOLIA_INDEX_NAME_PREFIX',
+		);
+
+		if ( ! in_array( $constant_name, $known_constants, true ) ) {
+			return;
+		}
+
+		// Translators: %s is a PHP constant name wrapped in <code> tags.
+		$body = sprintf(
+			/* translators: %s: PHP constant name (e.g. ALGOLIA_APPLICATION_ID) wrapped in <code>. */
+			__( 'This value is set by the %s constant and cannot be edited here.', 'wp-search-with-algolia' ),
+			'<code>' . esc_html( $constant_name ) . '</code>'
+		);
+
+		echo '<p class="algolia-field-locked">';
+		echo '<span class="dashicons dashicons-lock" aria-hidden="true"></span>';
+		echo '<span class="algolia-field-locked__text">';
+		echo '<strong>' . esc_html__( 'Defined in wp-config.php.', 'wp-search-with-algolia' ) . '</strong> ';
+		echo wp_kses( $body, array( 'code' => array() ) );
+		echo ' ';
+		echo esc_html__( 'Edit your wp-config.php file to change it.', 'wp-search-with-algolia' );
+		echo '</span>';
+		echo '</p>';
+	}
+}

--- a/includes/admin/class-algolia-admin-page-autocomplete.php
+++ b/includes/admin/class-algolia-admin-page-autocomplete.php
@@ -171,11 +171,28 @@ class Algolia_Admin_Page_Autocomplete {
 	public function autocomplete_enabled_callback() {
 		$value    = $this->settings->get_autocomplete_enabled();
 		$indices  = $this->autocomplete_config->get_form_data();
-		$checked  = 'yes' === $value ? 'checked ' : '';
-		$disabled = empty( $indices ) ? 'disabled ' : '';
+		$checked  = 'yes' === $value ? ' checked' : '';
+		$disabled = empty( $indices ) ? ' disabled' : '';
 		?>
-		<input type='checkbox' name='algolia_autocomplete_enabled' value='yes' <?php echo esc_html( $checked . ' ' . $disabled ); ?>/>
+		<label>
+			<input type="checkbox" name="algolia_autocomplete_enabled" value="yes"<?php echo esc_html( $checked . $disabled ); ?> />
+			<?php esc_html_e( 'Show an Algolia-powered dropdown of suggestions while visitors type in the site search.', 'wp-search-with-algolia' ); ?>
+		</label>
 		<?php
+
+		Algolia_Admin_Field_Helpers::render_field_help(
+			__( 'Adds search-as-you-type results to your site\'s existing search input(s).', 'wp-search-with-algolia' ),
+			array(
+				__( '<strong>What gets enhanced.</strong> The plugin attaches to inputs matching <code>input[name="s"]</code> by default, the standard WordPress search input. The dropdown appears as the visitor types and disappears when they click away or submit the form.', 'wp-search-with-algolia' ),
+				__( '<strong>Independent of the search results page.</strong> Autocomplete and the InstantSearch search results page (Search Page settings) are separate features. You can run autocomplete on its own, search results on their own, or both together.', 'wp-search-with-algolia' ),
+				__( '<strong>Targeting a different input.</strong> Use the <code>algolia_autocomplete_input_selector</code> filter to override the default selector if your theme uses a custom search field.', 'wp-search-with-algolia' ),
+			),
+			array(),
+			array(
+				'url'   => 'https://www.algolia.com/doc/ui-libraries/autocomplete/introduction/what-is-autocomplete/',
+				'label' => __( 'Read the Algolia Autocomplete documentation', 'wp-search-with-algolia' ),
+			)
+		);
 	}
 
 	/**
@@ -188,12 +205,23 @@ class Algolia_Admin_Page_Autocomplete {
 		$value   = $this->settings->get_autocomplete_debounce();
 		$indices = $this->autocomplete_config->get_form_data();
 		?>
-		<input type="number" name="algolia_autocomplete_debounce" class="small-text" min="0" value="<?php echo esc_attr( $value ); ?>" <?php disabled( empty( $indices ) ); ?>/>
-		<p class="description" id="home-description">
-			<?php esc_html_e( 'Enter the debounce timeout value in milliseconds. Use 0 (default) to disable debounce.', 'wp-search-with-algolia' ); ?>
-			<a href="https://www.algolia.com/doc/ui-libraries/autocomplete/guides/debouncing-sources/" target="_blank"><?php esc_html_e( 'Debouncing sources documentation', 'wp-search-with-algolia' ); ?></a>
-		</p>
+		<input type="number" name="algolia_autocomplete_debounce" class="small-text" min="0" step="50" value="<?php echo esc_attr( $value ); ?>" <?php disabled( empty( $indices ) ); ?>/>
+		<span class="algolia-input-suffix">ms</span>
 		<?php
+
+		Algolia_Admin_Field_Helpers::render_field_help(
+			__( 'Wait this many milliseconds after the visitor stops typing before sending a request to Algolia. Set to 0 to disable.', 'wp-search-with-algolia' ),
+			array(
+				__( '<strong>Why debounce.</strong> Without debouncing, every keystroke triggers a search request. On fast typists, that means many requests per second, most of them wasted, because only the final query matters to the visitor.', 'wp-search-with-algolia' ),
+				__( '<strong>Recommended starting point.</strong> <code>200</code> ms is a good default for most sites. Lower values feel snappier but increase request volume; higher values feel laggier but reduce load.', 'wp-search-with-algolia' ),
+				__( '<strong>Per-index override.</strong> A specific index can override this global value via the <code>debounce</code> property on its config; when set, that value is shown on the index card below.', 'wp-search-with-algolia' ),
+			),
+			array(),
+			array(
+				'url'   => 'https://www.algolia.com/doc/ui-libraries/autocomplete/guides/debouncing-sources/',
+				'label' => __( 'Read the debouncing sources guide', 'wp-search-with-algolia' ),
+			)
+		);
 	}
 
 	/**
@@ -211,7 +239,7 @@ class Algolia_Admin_Page_Autocomplete {
 		add_settings_error(
 			$this->option_group,
 			'autocomplete_enabled',
-			esc_html__( 'Autocomplete configuration has been saved. Make sure to hit the "re-index" buttons of the different indices that are not indexed yet.', 'wp-search-with-algolia' ),
+			esc_html__( 'Autocomplete settings saved. Run "Re-index" on any index that has not been indexed yet so its suggestions can appear in the dropdown.', 'wp-search-with-algolia' ),
 			'updated'
 		);
 
@@ -241,7 +269,18 @@ class Algolia_Admin_Page_Autocomplete {
 	public function autocomplete_config_callback() {
 		$indices = $this->autocomplete_config->get_form_data();
 
-		require_once dirname( __FILE__ ) . '/partials/page-autocomplete-config.php';
+		require dirname( __FILE__ ) . '/partials/page-autocomplete-config.php';
+
+		Algolia_Admin_Field_Helpers::render_field_help(
+			__( 'Each card below is one source the autocomplete dropdown can pull suggestions from. Toggle, reorder, and tune them to match how you want the dropdown to look.', 'wp-search-with-algolia' ),
+			array(
+				__( '<strong>Enable / disable.</strong> Use the toggle on each card to include that index in the dropdown. Disabled indices are still visible here so you can keep their settings without showing them to visitors.', 'wp-search-with-algolia' ),
+				__( '<strong>Reorder.</strong> Drag the handle on the left of each card to change the order sections appear in the dropdown.', 'wp-search-with-algolia' ),
+				__( '<strong>Section label.</strong> Shown as the heading above this group of suggestions in the dropdown (for example: <em>Articles</em>, <em>Products</em>, <em>Authors</em>).', 'wp-search-with-algolia' ),
+				__( '<strong>Max. suggestions.</strong> Controls how many results from this index appear in the dropdown. Keep totals modest. A dropdown that scrolls is harder to scan than 3 to 5 well-chosen sections.', 'wp-search-with-algolia' ),
+				__( '<strong>Re-index / Push settings.</strong> "Re-index" resends the records for that index. "Push settings" syncs ranking and searchable attributes up to Algolia. <strong>This overwrites changes you may have made directly in the Algolia dashboard.</strong>', 'wp-search-with-algolia' ),
+			)
+		);
 	}
 
 	/**
@@ -303,8 +342,13 @@ class Algolia_Admin_Page_Autocomplete {
 	 * @since  1.0.0
 	 */
 	public function print_section_settings() {
-		echo '<p>' . esc_html__( 'Autocomplete adds a search-as-you-type dropdown to your search field(s).', 'wp-search-with-algolia' ) . '</p>';
+		echo '<p>' . esc_html__( 'Show a dropdown of typo-tolerant suggestions while visitors type in your search field. Toggle the feature on, tune the timing, and choose which indices feed the dropdown.', 'wp-search-with-algolia' ) . '</p>';
 
-		echo '<p>' . esc_html__( 'Enabling Autocomplete adds the functionality to your site\'s frontend search. Indexing and settings pushes can be done regardless of enabled status.', 'wp-search-with-algolia' ) . '</p>';
+		$indices = $this->autocomplete_config->get_form_data();
+		if ( empty( $indices ) ) {
+			echo '<div class="notice notice-warning inline algolia-inline-notice"><p>' .
+				esc_html__( 'No indices are available yet. Configure at least one index on the Indexing page, then return here to choose which ones power the autocomplete dropdown.', 'wp-search-with-algolia' ) .
+				'</p></div>';
+		}
 	}
 }

--- a/includes/admin/class-algolia-admin-page-native-search.php
+++ b/includes/admin/class-algolia-admin-page-native-search.php
@@ -296,7 +296,7 @@ class Algolia_Admin_Page_Native_Search {
 		echo '<p>' . wp_kses(
 			sprintf(
 				/* translators: 1: Re-index button label, 2: explanation. */
-				__( '<strong>%1$s:</strong> resubmits your content to the Algolia search API. Search results refresh once indexing completes. Run this after switching modes for the first time, or any time your content has drifted out of sync.', 'wp-search-with-algolia' ),
+				__( '<strong>%1$s:</strong> resubmits your content to the Algolia search API. Search results refresh once indexing completes. Run this after switching modes for the first time, or any time you change content to be indexed, like new shared attributes, or bulk importing of content has been performed.', 'wp-search-with-algolia' ),
 				esc_html__( 'Re-index All Content', 'wp-search-with-algolia' )
 			),
 			array( 'strong' => array() )

--- a/includes/admin/class-algolia-admin-page-native-search.php
+++ b/includes/admin/class-algolia-admin-page-native-search.php
@@ -115,7 +115,7 @@ class Algolia_Admin_Page_Native_Search {
 
 		add_settings_field(
 			'algolia_override_native_search',
-			esc_html__( 'Search results', 'wp-search-with-algolia' ),
+			esc_html__( 'Search results source', 'wp-search-with-algolia' ),
 			array( $this, 'override_native_search_callback' ),
 			$this->slug,
 			$this->section
@@ -123,8 +123,8 @@ class Algolia_Admin_Page_Native_Search {
 
 		add_settings_field(
 			'algolia_instantsearch_template_version',
-			esc_html__( 'Instantsearch Template version', 'wp-search-with-algolia' ),
-			[ $this, 'instantsearch_template_version' ],
+			esc_html__( 'InstantSearch template', 'wp-search-with-algolia' ),
+			array( $this, 'instantsearch_template_version' ),
 			$this->slug,
 			$this->section
 		);
@@ -151,7 +151,22 @@ class Algolia_Admin_Page_Native_Search {
 	public function override_native_search_callback() {
 		$value = $this->plugin->get_settings()->get_override_native_search();
 
-		require_once dirname( __FILE__ ) . '/partials/form-override-search-option.php';
+		require dirname( __FILE__ ) . '/partials/form-override-search-option.php';
+
+		Algolia_Admin_Field_Helpers::render_field_help(
+			__( 'Choose how WordPress search queries are answered. You can change this at any time.', 'wp-search-with-algolia' ),
+			array(
+				__( '<strong>Why use Algolia for search?</strong> Algolia returns ranked, typo-tolerant results in milliseconds, even on large sites. The standard WordPress search runs SQL <code>LIKE</code> queries, which slow down with content volume and miss close matches.', 'wp-search-with-algolia' ),
+				__( '<strong>Switching is non-destructive.</strong> Your WordPress content is never modified. The plugin only changes how the search query is run and how the results page is rendered. Switch back to the standard WordPress search at any time.', 'wp-search-with-algolia' ),
+				__( '<strong>Block (FSE) themes &amp; InstantSearch.</strong> If your active theme is a block theme (such as Twenty Twenty-Four or Twenty Twenty-Five), the plugin enqueues the InstantSearch assets but lets your block template render the page. You will need to add the InstantSearch markup yourself in the theme&rsquo;s search template, or copy <code>templates/instantsearch.php</code> into <code>your-theme/algolia/</code> and force the classic template by returning <code>false</code> from the <code>algolia_is_block_theme</code> filter.', 'wp-search-with-algolia' ),
+				__( '<strong>Indexing is required.</strong> Algolia can only return what has been indexed. Use the <strong>Re-index All Content</strong> button at the top of this page after your first switch.', 'wp-search-with-algolia' ),
+			),
+			array(),
+			array(
+				'url'   => 'https://www.algolia.com/doc/guides/building-search-ui/what-is-instantsearch/js/',
+				'label' => __( 'Read the InstantSearch.js overview', 'wp-search-with-algolia' ),
+			)
+		);
 	}
 
 	/**
@@ -163,7 +178,22 @@ class Algolia_Admin_Page_Native_Search {
 	public function instantsearch_template_version() {
 		$value = $this->plugin->get_settings()->get_instantsearch_template_version();
 
-		require_once dirname( __FILE__ ) . '/partials/form-override-search-version-option.php';
+		require dirname( __FILE__ ) . '/partials/form-override-search-version-option.php';
+
+		Algolia_Admin_Field_Helpers::render_field_help(
+			__( 'Only applies when "Use Algolia with InstantSearch.js" is selected above. Pick the template style your front-end search will use.', 'wp-search-with-algolia' ),
+			array(
+				__( '<strong>What this controls.</strong> Two reference templates ship with the plugin in <code>templates/instantsearch.php</code> and <code>templates/instantsearch-modern.php</code>. This setting decides which one the plugin loads on your search results page.', 'wp-search-with-algolia' ),
+				__( '<strong>When to pick Legacy.</strong> Existing sites that already customized the older template, or have integrations relying on the WP Utils JavaScript helpers.', 'wp-search-with-algolia' ),
+				__( '<strong>When to pick Modern.</strong> New installs and any site that wants to follow the patterns shown in current Algolia documentation.', 'wp-search-with-algolia' ),
+				__( '<strong>Customizing the template.</strong> Copy the file you chose into <code>your-theme/algolia/</code> and the plugin will load your copy instead. Switching this setting does <strong>not</strong> overwrite a customized template in your theme.', 'wp-search-with-algolia' ),
+			),
+			array(),
+			array(
+				'url'   => 'https://www.algolia.com/doc/guides/building-search-ui/widgets/showcase/js/',
+				'label' => __( 'Browse InstantSearch widget examples', 'wp-search-with-algolia' ),
+			)
+		);
 	}
 
 	/**
@@ -258,20 +288,29 @@ class Algolia_Admin_Page_Native_Search {
 	 * @since  1.0.0
 	 */
 	public function print_section_settings() {
-		echo '<p>' . esc_html__( 'By enabling these settings to override the native WordPress search, your search results will be powered by Algolia\'s typo-tolerant & relevant search algorithms.', 'wp-search-with-algolia' ) . '</p>';
+		echo '<p>' . esc_html__( 'Choose how WordPress should answer search queries, and pick the InstantSearch template style if you turn that experience on.', 'wp-search-with-algolia' ) . '</p>';
 
-		echo '<p>' . sprintf(
-			'<strong>%1$s</strong> - %2$s',
-			esc_html__( 'Re-index All Content', 'wp-search-with-algolia' ),
-			esc_html__( 'Resubmit all of your content to the Algolia search API. Search results will be updated once the re-index has completed.', 'wp-search-with-algolia' )
+		echo '<details class="algolia-field-help algolia-field-help--inline">';
+		echo '<summary>' . esc_html__( 'About the Re-index All Content and Push Settings buttons', 'wp-search-with-algolia' ) . '</summary>';
+		echo '<div class="algolia-field-help__body">';
+		echo '<p>' . wp_kses(
+			sprintf(
+				/* translators: 1: Re-index button label, 2: explanation. */
+				__( '<strong>%1$s:</strong> resubmits your content to the Algolia search API. Search results refresh once indexing completes. Run this after switching modes for the first time, or any time your content has drifted out of sync.', 'wp-search-with-algolia' ),
+				esc_html__( 'Re-index All Content', 'wp-search-with-algolia' )
+			),
+			array( 'strong' => array() )
 		) . '</p>';
-
-		echo '<p>' . sprintf(
-			'<strong>%1$s</strong> - %2$s <strong>%3$s</strong>',
-			esc_html__( 'Push Settings', 'wp-search-with-algolia' ),
-			esc_html__( 'Sync your search index settings to code-based overrides and plugin defaults.', 'wp-search-with-algolia' ),
-			esc_html__( 'WARNING this will override or reset configuration changes originally made within your Algolia dashboard.', 'wp-search-with-algolia' )
+		echo '<p>' . wp_kses(
+			sprintf(
+				/* translators: 1: Push Settings button label, 2: explanation, 3: warning. */
+				__( '<strong>%1$s:</strong> pushes the index settings configured in this plugin (ranking, searchable attributes, facets) up to Algolia. <strong>%2$s</strong>', 'wp-search-with-algolia' ),
+				esc_html__( 'Push Settings', 'wp-search-with-algolia' ),
+				esc_html__( 'Warning: this overwrites changes you may have made directly in the Algolia dashboard.', 'wp-search-with-algolia' )
+			),
+			array( 'strong' => array() )
 		) . '</p>';
+		echo '</div></details>';
 
 		// @Todo: replace this with a check on the searchable_posts_index.
 		$indices = $this->plugin->get_indices(
@@ -282,9 +321,9 @@ class Algolia_Admin_Page_Native_Search {
 		);
 
 		if ( empty( $indices ) ) {
-			echo '<div class="error-message"><p>' .
-					esc_html( __( 'You have no index containing only posts yet. Please index some content with the "Re-index All Content" button above.', 'wp-search-with-algolia' ) ) .
-					'</p></div>';
+			echo '<div class="notice notice-warning inline algolia-inline-notice"><p>' .
+				esc_html__( 'No posts have been indexed yet. Click "Re-index All Content" at the top of this page once your credentials are saved.', 'wp-search-with-algolia' ) .
+				'</p></div>';
 		}
 	}
 }

--- a/includes/admin/class-algolia-admin-page-settings.php
+++ b/includes/admin/class-algolia-admin-page-settings.php
@@ -242,13 +242,13 @@ class Algolia_Admin_Page_Settings {
 		Algolia_Admin_Field_Helpers::render_field_help(
 			__( 'Your unique Algolia Application ID.', 'wp-search-with-algolia' ),
 			array(
-				__( 'Find this in your Algolia dashboard under <strong>Settings &rarr; API Keys</strong>. It is a short string of letters and numbers (for example <code>LATENCY</code>) that identifies your Algolia application.', 'wp-search-with-algolia' ),
+				__( 'Find this on the <strong>API Keys</strong> page in your Algolia dashboard. It is a short string of letters and numbers (for example <code>LATENCY</code>) that identifies your Algolia application.', 'wp-search-with-algolia' ),
 			),
-			array(),
-			array(
+			[],
+			[
 				'url'   => 'https://dashboard.algolia.com/account/api-keys/all',
 				'label' => __( 'Open the API Keys page in your Algolia dashboard', 'wp-search-with-algolia' ),
-			)
+			]
 		);
 	}
 

--- a/includes/admin/class-algolia-admin-page-settings.php
+++ b/includes/admin/class-algolia-admin-page-settings.php
@@ -303,12 +303,12 @@ class Algolia_Admin_Page_Settings {
 			Algolia_Admin_Field_Helpers::render_constant_locked_notice( 'ALGOLIA_API_KEY' );
 		}
 		Algolia_Admin_Field_Helpers::render_field_help(
-			__( 'Private key used by WordPress to push and update your indices. Never share it.', 'wp-search-with-algolia' ),
+			esc_html__( 'Private key used by WordPress to push and update your indices. Never share it.', 'wp-search-with-algolia' ),
 			array(
 				__( 'Find this on the <strong>API Keys</strong> page in your Algolia dashboard. WordPress uses this key on the server side to create indices, push records, and update settings. It is <strong>never</strong> sent to the browser.', 'wp-search-with-algolia' ),
 			),
 			array(
-				__( 'Treat this like a password. Anyone with it can modify or delete your Algolia data.', 'wp-search-with-algolia' ),
+				esc_html__( 'Treat this like a password. Anyone with it can modify or delete your Algolia data.', 'wp-search-with-algolia' ),
 				__( 'Tip: store it in <code>wp-config.php</code> as <code>ALGOLIA_API_KEY</code> if you would rather keep it out of the database.', 'wp-search-with-algolia' ),
 			),
 			array(
@@ -336,12 +336,12 @@ class Algolia_Admin_Page_Settings {
 			Algolia_Admin_Field_Helpers::render_constant_locked_notice( 'ALGOLIA_INDEX_NAME_PREFIX' );
 		}
 		Algolia_Admin_Field_Helpers::render_field_help(
-			__( 'Prepended to every index this site creates in Algolia.', 'wp-search-with-algolia' ),
+			esc_html__( 'Prepended to every index this site creates in Algolia.', 'wp-search-with-algolia' ),
 			array(
 				__( 'Use a unique prefix for each WordPress environment that shares the same Algolia application: for example <code>prod_</code>, <code>staging_</code>, or <code>dev_</code>. This prevents environments from overwriting each other&rsquo;s indices.', 'wp-search-with-algolia' ),
 			),
 			array(
-				__( 'Allowed characters: letters, numbers, and underscores.', 'wp-search-with-algolia' ),
+				esc_html__( 'Allowed characters: letters, numbers, and underscores.', 'wp-search-with-algolia' ),
 				__( 'Default: <code>wp_</code>. Changing this after indexing will require a re-index of your content.', 'wp-search-with-algolia' ),
 			)
 		);
@@ -364,14 +364,14 @@ class Algolia_Admin_Page_Settings {
 		echo '</label>';
 
 		Algolia_Admin_Field_Helpers::render_field_help(
-			__( 'Controls whether the &ldquo;Powered by Algolia&rdquo; logo appears alongside your search results.', 'wp-search-with-algolia' ),
+			esc_html__( 'Controls whether the &ldquo;Powered by Algolia&rdquo; logo appears alongside your search results.', 'wp-search-with-algolia' ),
 			array(
 				__( '<strong>Algolia&rsquo;s Terms of Service require the logo to remain visible on the free Community plan.</strong> Only enable this option if you are on a paid Algolia plan that permits removing the logo.', 'wp-search-with-algolia' ),
 			),
 			array(),
 			array(
 				'url'   => 'https://www.algolia.com/pricing/',
-				'label' => __( 'Compare Algolia plans', 'wp-search-with-algolia' ),
+				'label' => esc_html__( 'Compare Algolia plans', 'wp-search-with-algolia' ),
 			)
 		);
 	}
@@ -392,7 +392,7 @@ class Algolia_Admin_Page_Settings {
 		echo '</label>';
 
 		Algolia_Admin_Field_Helpers::render_field_help(
-			__( 'Powers your Algolia analytics dashboard and helps Algolia rank the most useful results higher.', 'wp-search-with-algolia' ),
+			esc_html__( 'Powers your Algolia analytics dashboard and helps Algolia rank the most useful results higher.', 'wp-search-with-algolia' ),
 			array(
 				__( '<strong>What it does.</strong> When enabled, the plugin sends anonymous events to Algolia each time a visitor interacts with your search results. Specifically, it tracks:', 'wp-search-with-algolia' ),
 				array(
@@ -411,7 +411,7 @@ class Algolia_Admin_Page_Settings {
 			array(),
 			array(
 				'url'   => 'https://www.algolia.com/doc/guides/building-search-ui/events/js/',
-				'label' => __( 'Read the Algolia Insights & events documentation', 'wp-search-with-algolia' ),
+				'label' => esc_html__( 'Read the Algolia Insights & events documentation', 'wp-search-with-algolia' ),
 			)
 		);
 	}

--- a/includes/admin/class-algolia-admin-page-settings.php
+++ b/includes/admin/class-algolia-admin-page-settings.php
@@ -36,14 +36,22 @@ class Algolia_Admin_Page_Settings {
 	private $capability = 'manage_options';
 
 	/**
-	 * Admin page section.
+	 * Credentials settings section ID.
 	 *
-	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  1.0.0
+	 * @since 2.11.0
 	 *
 	 * @var string
 	 */
-	private $section = 'algolia_section_settings';
+	private $section_credentials = 'algolia_section_credentials';
+
+	/**
+	 * Display & analytics settings section ID.
+	 *
+	 * @since 2.11.0
+	 *
+	 * @var string
+	 */
+	private $section_display = 'algolia_section_display';
 
 	/**
 	 * Admin page option group.
@@ -144,9 +152,16 @@ class Algolia_Admin_Page_Settings {
 	 */
 	public function add_settings() {
 		add_settings_section(
-			$this->section,
-			null,
-			array( $this, 'print_section_settings' ),
+			$this->section_credentials,
+			esc_html__( 'Algolia account credentials', 'wp-search-with-algolia' ),
+			array( $this, 'print_section_credentials' ),
+			$this->slug
+		);
+
+		add_settings_section(
+			$this->section_display,
+			esc_html__( 'Display & analytics', 'wp-search-with-algolia' ),
+			array( $this, 'print_section_display' ),
 			$this->slug
 		);
 
@@ -155,47 +170,47 @@ class Algolia_Admin_Page_Settings {
 			esc_html__( 'Application ID', 'wp-search-with-algolia' ),
 			array( $this, 'application_id_callback' ),
 			$this->slug,
-			$this->section
+			$this->section_credentials
 		);
 
 		add_settings_field(
 			'algolia_search_api_key',
-			esc_html__( 'Search API key', 'wp-search-with-algolia' ),
+			esc_html__( 'Search-Only API Key', 'wp-search-with-algolia' ),
 			array( $this, 'search_api_key_callback' ),
 			$this->slug,
-			$this->section
+			$this->section_credentials
 		);
 
 		add_settings_field(
 			'algolia_api_key',
-			esc_html__( 'Admin API key', 'wp-search-with-algolia' ),
+			esc_html__( 'Admin API Key', 'wp-search-with-algolia' ),
 			array( $this, 'api_key_callback' ),
 			$this->slug,
-			$this->section
+			$this->section_credentials
 		);
 
 		add_settings_field(
 			'algolia_index_name_prefix',
-			esc_html__( 'Index name prefix', 'wp-search-with-algolia' ),
+			esc_html__( 'Index Name Prefix', 'wp-search-with-algolia' ),
 			array( $this, 'index_name_prefix_callback' ),
 			$this->slug,
-			$this->section
+			$this->section_credentials
 		);
 
 		add_settings_field(
 			'algolia_powered_by_enabled',
-			esc_html__( 'Remove Algolia powered by logo', 'wp-search-with-algolia' ),
+			esc_html__( 'Algolia "Powered by" Logo', 'wp-search-with-algolia' ),
 			array( $this, 'powered_by_enabled_callback' ),
 			$this->slug,
-			$this->section
+			$this->section_display
 		);
 
 		add_settings_field(
 			'algolia_insights_enabled',
-			esc_html__( 'Enable Insight events', 'wp-search-with-algolia' ),
+			esc_html__( 'Send Click & Conversion Events to Algolia', 'wp-search-with-algolia' ),
 			array( $this, 'insights_enabled_callback' ),
 			$this->slug,
-			$this->section
+			$this->section_display
 		);
 
 		register_setting( $this->option_group, 'algolia_application_id', array( $this, 'sanitize_application_id' ) );
@@ -216,13 +231,25 @@ class Algolia_Admin_Page_Settings {
 
 		$settings      = $this->plugin->get_settings();
 		$setting       = $settings->get_application_id();
-		$disabled_html = $settings->is_application_id_in_config() ? ' disabled' : '';
+		$is_locked     = $settings->is_application_id_in_config();
+		$disabled_html = $is_locked ? ' disabled' : '';
 		?>
 		<input type="text" name="algolia_application_id" class="regular-text" value="<?php echo esc_attr( $setting ); ?>" <?php echo esc_html( $disabled_html ); ?>/>
-		<p class="description" id="home-description">
-			<?php esc_html_e( 'Your Algolia Application ID.', 'wp-search-with-algolia' ); ?>
-		</p>
 		<?php
+		if ( $is_locked ) {
+			Algolia_Admin_Field_Helpers::render_constant_locked_notice( 'ALGOLIA_APPLICATION_ID' );
+		}
+		Algolia_Admin_Field_Helpers::render_field_help(
+			__( 'Your unique Algolia Application ID.', 'wp-search-with-algolia' ),
+			array(
+				__( 'Find this in your Algolia dashboard under <strong>Settings &rarr; API Keys</strong>. It is a short string of letters and numbers (for example <code>LATENCY</code>) that identifies your Algolia application.', 'wp-search-with-algolia' ),
+			),
+			array(),
+			array(
+				'url'   => 'https://dashboard.algolia.com/account/api-keys/all',
+				'label' => __( 'Open the API Keys page in your Algolia dashboard', 'wp-search-with-algolia' ),
+			)
+		);
 	}
 
 	/**
@@ -234,14 +261,28 @@ class Algolia_Admin_Page_Settings {
 	public function search_api_key_callback() {
 		$settings      = $this->plugin->get_settings();
 		$setting       = $settings->get_search_api_key();
-		$disabled_html = $settings->is_search_api_key_in_config() ? ' disabled' : '';
-
+		$is_locked     = $settings->is_search_api_key_in_config();
+		$disabled_html = $is_locked ? ' disabled' : '';
 		?>
 		<input type="text" name="algolia_search_api_key" class="regular-text" value="<?php echo esc_attr( $setting ); ?>" <?php echo esc_html( $disabled_html ); ?>/>
-		<p class="description" id="home-description">
-			<?php esc_html_e( 'Your Algolia Search API key (public).', 'wp-search-with-algolia' ); ?>
-		</p>
 		<?php
+		if ( $is_locked ) {
+			Algolia_Admin_Field_Helpers::render_constant_locked_notice( 'ALGOLIA_SEARCH_API_KEY' );
+		}
+		Algolia_Admin_Field_Helpers::render_field_help(
+			__( 'Public, search-only key safe to expose to your visitors.', 'wp-search-with-algolia' ),
+			array(
+				__( 'Find this on the <strong>API Keys</strong> page in your Algolia dashboard. The Search-Only key is included in the JavaScript that runs on your site, so it must be the search-only key, never the Admin key.', 'wp-search-with-algolia' ),
+			),
+			array(
+				__( 'Has search permission only. It cannot modify or delete data.', 'wp-search-with-algolia' ),
+				__( 'Should not have a time-limited validity, or your front-end search will stop working when it expires.', 'wp-search-with-algolia' ),
+			),
+			array(
+				'url'   => 'https://dashboard.algolia.com/account/api-keys/all',
+				'label' => __( 'Open the API Keys page in your Algolia dashboard', 'wp-search-with-algolia' ),
+			)
+		);
 	}
 
 	/**
@@ -253,13 +294,28 @@ class Algolia_Admin_Page_Settings {
 	public function api_key_callback() {
 		$settings      = $this->plugin->get_settings();
 		$setting       = $settings->get_api_key();
-		$disabled_html = $settings->is_api_key_in_config() ? ' disabled' : '';
+		$is_locked     = $settings->is_api_key_in_config();
+		$disabled_html = $is_locked ? ' disabled' : '';
 		?>
 		<input type="password" name="algolia_api_key" class="regular-text" value="<?php echo esc_attr( $setting ); ?>" <?php echo esc_html( $disabled_html ); ?>/>
-		<p class="description" id="home-description">
-			<?php esc_html_e( 'Your Algolia ADMIN API key (kept private).', 'wp-search-with-algolia' ); ?>
-		</p>
 		<?php
+		if ( $is_locked ) {
+			Algolia_Admin_Field_Helpers::render_constant_locked_notice( 'ALGOLIA_API_KEY' );
+		}
+		Algolia_Admin_Field_Helpers::render_field_help(
+			__( 'Private key used by WordPress to push and update your indices. Never share it.', 'wp-search-with-algolia' ),
+			array(
+				__( 'Find this on the <strong>API Keys</strong> page in your Algolia dashboard. WordPress uses this key on the server side to create indices, push records, and update settings. It is <strong>never</strong> sent to the browser.', 'wp-search-with-algolia' ),
+			),
+			array(
+				__( 'Treat this like a password. Anyone with it can modify or delete your Algolia data.', 'wp-search-with-algolia' ),
+				__( 'Tip: store it in <code>wp-config.php</code> as <code>ALGOLIA_API_KEY</code> if you would rather keep it out of the database.', 'wp-search-with-algolia' ),
+			),
+			array(
+				'url'   => 'https://www.algolia.com/doc/guides/security/api-keys/',
+				'label' => __( 'Read the Algolia API keys guide', 'wp-search-with-algolia' ),
+			)
+		);
 	}
 
 	/**
@@ -271,11 +327,24 @@ class Algolia_Admin_Page_Settings {
 	public function index_name_prefix_callback() {
 		$settings          = $this->plugin->get_settings();
 		$index_name_prefix = $settings->get_index_name_prefix();
-		$disabled_html     = $settings->is_index_name_prefix_in_config() ? ' disabled' : '';
+		$is_locked         = $settings->is_index_name_prefix_in_config();
+		$disabled_html     = $is_locked ? ' disabled' : '';
 		?>
 		<input type="text" name="algolia_index_name_prefix" value="<?php echo esc_attr( $index_name_prefix ); ?>" <?php echo esc_html( $disabled_html ); ?>/>
-		<p class="description" id="home-description"><?php esc_html_e( 'This prefix will be prepended to your index names.', 'wp-search-with-algolia' ); ?></p>
 		<?php
+		if ( $is_locked ) {
+			Algolia_Admin_Field_Helpers::render_constant_locked_notice( 'ALGOLIA_INDEX_NAME_PREFIX' );
+		}
+		Algolia_Admin_Field_Helpers::render_field_help(
+			__( 'Prepended to every index this site creates in Algolia.', 'wp-search-with-algolia' ),
+			array(
+				__( 'Use a unique prefix for each WordPress environment that shares the same Algolia application: for example <code>prod_</code>, <code>staging_</code>, or <code>dev_</code>. This prevents environments from overwriting each other&rsquo;s indices.', 'wp-search-with-algolia' ),
+			),
+			array(
+				__( 'Allowed characters: letters, numbers, and underscores.', 'wp-search-with-algolia' ),
+				__( 'Default: <code>wp_</code>. Changing this after indexing will require a re-index of your content.', 'wp-search-with-algolia' ),
+			)
+		);
 	}
 
 	/**
@@ -290,8 +359,21 @@ class Algolia_Admin_Page_Settings {
 		if ( ! $powered_by_enabled ) {
 			$checked = ' checked';
 		}
-		echo "<input type='checkbox' name='algolia_powered_by_enabled' value='no' " . esc_html( $checked ) . ' />' .
-			'<p class="description" id="home-description">' . esc_html( __( 'This will remove the Algolia logo from the autocomplete and the search page. Algolia requires that you keep the logo if you are using a free plan.', 'wp-search-with-algolia' ) ) . '</p>';
+		echo '<label><input type="checkbox" name="algolia_powered_by_enabled" value="no"' . esc_html( $checked ) . ' /> ';
+		echo esc_html__( 'Hide the Algolia logo on the autocomplete dropdown and search results page.', 'wp-search-with-algolia' );
+		echo '</label>';
+
+		Algolia_Admin_Field_Helpers::render_field_help(
+			__( 'Controls whether the &ldquo;Powered by Algolia&rdquo; logo appears alongside your search results.', 'wp-search-with-algolia' ),
+			array(
+				__( '<strong>Algolia&rsquo;s Terms of Service require the logo to remain visible on the free Community plan.</strong> Only enable this option if you are on a paid Algolia plan that permits removing the logo.', 'wp-search-with-algolia' ),
+			),
+			array(),
+			array(
+				'url'   => 'https://www.algolia.com/pricing/',
+				'label' => __( 'Compare Algolia plans', 'wp-search-with-algolia' ),
+			)
+		);
 	}
 
 	/**
@@ -305,8 +387,33 @@ class Algolia_Admin_Page_Settings {
 		if ( $insights_enabled ) {
 			$checked = ' checked';
 		}
-		echo "<input type='checkbox' name='algolia_insights_enabled' value='yes' " . esc_html( $checked ) . ' />' .
-			'<p class="description" id="home-description">' . esc_html( __( 'This will enable insights and events tracking to help boost your Algolia results.', 'wp-search-with-algolia' ) ) . '</p>';
+		echo '<label><input type="checkbox" name="algolia_insights_enabled" value="yes"' . esc_html( $checked ) . ' /> ';
+		echo esc_html__( 'Send anonymous click and conversion events from your search to Algolia.', 'wp-search-with-algolia' );
+		echo '</label>';
+
+		Algolia_Admin_Field_Helpers::render_field_help(
+			__( 'Powers your Algolia analytics dashboard and helps Algolia rank the most useful results higher.', 'wp-search-with-algolia' ),
+			array(
+				__( '<strong>What it does.</strong> When enabled, the plugin sends anonymous events to Algolia each time a visitor interacts with your search results. Specifically, it tracks:', 'wp-search-with-algolia' ),
+				array(
+					__( '<strong>Clicks:</strong> which result a visitor clicked, and where it appeared in the list.', 'wp-search-with-algolia' ),
+					__( '<strong>Conversions:</strong> when a clicked result is treated as a successful outcome.', 'wp-search-with-algolia' ),
+					__( '<strong>Queries:</strong> the search term tied to each click or conversion.', 'wp-search-with-algolia' ),
+				),
+				__( '<strong>Why turn it on.</strong> These events feed two things in your Algolia dashboard:', 'wp-search-with-algolia' ),
+				array(
+					__( '<strong>Analytics:</strong> see top searches, click-through rates, and no-result queries under the <strong>Analytics</strong> section of your Algolia dashboard.', 'wp-search-with-algolia' ),
+					__( '<strong>Better relevance:</strong> Algolia&rsquo;s Dynamic Re-Ranking and Personalization features use these events to surface the results your visitors actually find useful.', 'wp-search-with-algolia' ),
+				),
+				__( '<strong>Privacy.</strong> Events are sent with an <em>anonymous user token</em> generated per browser session. No WordPress user IDs, IP addresses, email addresses, or other personally identifiable information are sent. The token only has meaning inside Algolia&rsquo;s analytics.', 'wp-search-with-algolia' ),
+				__( '<strong>How to verify it&rsquo;s working.</strong> After enabling, perform a search on your site and click a result. Within a few minutes the event should appear in your Algolia dashboard under <strong>Data Sources &rarr; Events</strong>. Use the <strong>Events Debugger</strong> tab for live inspection.', 'wp-search-with-algolia' ),
+			),
+			array(),
+			array(
+				'url'   => 'https://www.algolia.com/doc/guides/building-search-ui/events/js/',
+				'label' => __( 'Read the Algolia Insights & events documentation', 'wp-search-with-algolia' ),
+			)
+		);
 	}
 
 	/**
@@ -538,32 +645,46 @@ class Algolia_Admin_Page_Settings {
 	}
 
 	/**
-	 * Print the settings section.
+	 * Print the credentials section intro.
 	 *
-	 * @author WebDevStudios <contact@webdevstudios.com>
-	 * @since  1.0.0
+	 * @since 2.11.0
 	 */
-	public function print_section_settings() {
-		echo '<p>' .
-			wp_kses(
-				sprintf(
-					// translators: URL to API keys section in Algolia dashboard.
-					__( 'Configure your Algolia account credentials. You can find them in the <a href="%s" target="_blank">API Keys</a> section of your Algolia dashboard.', 'wp-search-with-algolia' ),
-					'https://dashboard.algolia.com/account/api-keys/all'
-				),
-				[
-					'a' => [
-						'href'   => [],
-						'target' => [],
-					],
-				]
-			) . '</p>';
-		// translators: the placeholder contains the URL to Algolia's website.
-		echo '<p>' . wp_kses_post( sprintf( __( 'No Algolia account yet? <a href="%s">Follow this link</a> to create one for free in a couple of minutes!', 'wp-search-with-algolia' ), 'https://dashboard.algolia.com/users/sign_up' ) ) . '</p>';
+	public function print_section_credentials() {
+		$allowed = array(
+			'a' => array(
+				'href'   => array(),
+				'target' => array(),
+				'rel'    => array(),
+			),
+		);
 
-		echo '<p>' . esc_html__( 'Once you provide your Algolia Application ID and API key, this plugin will be able to securely communicate with Algolia servers.', 'wp-search-with-algolia' ) . '<br/>' . esc_html__( 'We ensure your information is correct by testing them against the Algolia servers upon save.', 'wp-search-with-algolia' ) . '</p>';
-		?>
-		<a href="https://dashboard.algolia.com/account/api-keys/all" target="_blank"><?php esc_html_e( 'Manage your Algolia API Keys', 'wp-search-with-algolia' ); ?></a>
-		<?php
+		echo '<p>' . wp_kses(
+			sprintf(
+				/* translators: %s: URL to API keys section in Algolia dashboard. */
+				__( 'Connect WordPress to your Algolia account. You can find these credentials in the <a href="%s" target="_blank" rel="noopener noreferrer">API Keys</a> section of your Algolia dashboard.', 'wp-search-with-algolia' ),
+				'https://dashboard.algolia.com/account/api-keys/all'
+			),
+			$allowed
+		) . '</p>';
+
+		echo '<p>' . wp_kses(
+			sprintf(
+				/* translators: %s: URL to Algolia signup page. */
+				__( 'No Algolia account yet? <a href="%s" target="_blank" rel="noopener noreferrer">Create one for free</a> in a couple of minutes.', 'wp-search-with-algolia' ),
+				'https://dashboard.algolia.com/users/sign_up'
+			),
+			$allowed
+		) . '</p>';
+
+		echo '<p class="description">' . esc_html__( 'When you save this page, the plugin will test your credentials against the Algolia servers.', 'wp-search-with-algolia' ) . '</p>';
+	}
+
+	/**
+	 * Print the display & analytics section intro.
+	 *
+	 * @since 2.11.0
+	 */
+	public function print_section_display() {
+		echo '<p>' . esc_html__( 'Control how the Algolia logo appears on your site and choose whether to send anonymous click and conversion events back to Algolia.', 'wp-search-with-algolia' ) . '</p>';
 	}
 }

--- a/includes/admin/class-algolia-admin-page-settings.php
+++ b/includes/admin/class-algolia-admin-page-settings.php
@@ -175,7 +175,7 @@ class Algolia_Admin_Page_Settings {
 
 		add_settings_field(
 			'algolia_search_api_key',
-			esc_html__( 'Search-Only API Key', 'wp-search-with-algolia' ),
+			esc_html__( 'Search API Key', 'wp-search-with-algolia' ),
 			array( $this, 'search_api_key_callback' ),
 			$this->slug,
 			$this->section_credentials
@@ -270,18 +270,18 @@ class Algolia_Admin_Page_Settings {
 			Algolia_Admin_Field_Helpers::render_constant_locked_notice( 'ALGOLIA_SEARCH_API_KEY' );
 		}
 		Algolia_Admin_Field_Helpers::render_field_help(
-			__( 'Public, search-only key safe to expose to your visitors.', 'wp-search-with-algolia' ),
-			array(
-				__( 'Find this on the <strong>API Keys</strong> page in your Algolia dashboard. The Search-Only key is included in the JavaScript that runs on your site, so it must be the search-only key, never the Admin key.', 'wp-search-with-algolia' ),
-			),
-			array(
-				__( 'Has search permission only. It cannot modify or delete data.', 'wp-search-with-algolia' ),
-				__( 'Should not have a time-limited validity, or your front-end search will stop working when it expires.', 'wp-search-with-algolia' ),
-			),
-			array(
+			esc_html__( 'Public, search key safe to expose to your visitors.', 'wp-search-with-algolia' ),
+			[
+				__( 'Find this on the <strong>API Keys</strong> page in your Algolia dashboard. The Search key is included in the JavaScript that runs on your site, so it must be the search key, never the Admin key.', 'wp-search-with-algolia' ),
+			],
+			[
+				esc_html__( 'Has search permission only. It cannot modify or delete data.', 'wp-search-with-algolia' ),
+				esc_html__( 'Should not have a time-limited validity, or your front-end search will stop working when it expires.', 'wp-search-with-algolia' ),
+			],
+			[
 				'url'   => 'https://dashboard.algolia.com/account/api-keys/all',
-				'label' => __( 'Open the API Keys page in your Algolia dashboard', 'wp-search-with-algolia' ),
-			)
+				'label' => esc_html__( 'Open the API Keys page in your Algolia dashboard', 'wp-search-with-algolia' ),
+			]
 		);
 	}
 

--- a/includes/admin/class-algolia-admin.php
+++ b/includes/admin/class-algolia-admin.php
@@ -77,7 +77,12 @@ class Algolia_Admin {
 	 * @since   1.0.0
 	 */
 	public function enqueue_styles() {
-		wp_enqueue_style( 'algolia-admin', plugin_dir_url( __FILE__ ) . 'css/algolia-admin.css', array(), ALGOLIA_VERSION );
+		wp_enqueue_style(
+			'algolia-admin',
+			plugin_dir_url( __FILE__ ) . 'css/algolia-admin.css',
+			array(),
+			$this->asset_version( __DIR__ . '/css/algolia-admin.css' )
+		);
 	}
 
 	/**
@@ -91,23 +96,45 @@ class Algolia_Admin {
 			'algolia-admin',
 			plugin_dir_url( __FILE__ ) . 'js/algolia-admin.js',
 			array( 'jquery', 'jquery-ui-sortable' ),
-			ALGOLIA_VERSION,
+			$this->asset_version( __DIR__ . '/js/algolia-admin.js' ),
 			false
 		);
 		wp_enqueue_script(
 			'algolia-admin-reindex-button',
 			plugin_dir_url( __FILE__ ) . 'js/reindex-button.js',
 			array( 'jquery' ),
-			ALGOLIA_VERSION,
+			$this->asset_version( __DIR__ . '/js/reindex-button.js' ),
 			false
 		);
 		wp_enqueue_script(
 			'algolia-admin-push-settings-button',
 			plugin_dir_url( __FILE__ ) . 'js/push-settings-button.js',
 			array( 'jquery' ),
-			ALGOLIA_VERSION,
+			$this->asset_version( __DIR__ . '/js/push-settings-button.js' ),
 			false
 		);
+	}
+
+	/**
+	 * Build a cache-busting version string for an admin asset.
+	 *
+	 * Uses the file's modification time so edits to bundled CSS/JS bust the
+	 * browser cache without needing to bump ALGOLIA_VERSION. Falls back to the
+	 * plugin version if the file cannot be read.
+	 *
+	 * @since 2.11.0
+	 *
+	 * @param string $path Absolute path to the asset.
+	 * @return string Version string suitable for wp_enqueue_*.
+	 */
+	private function asset_version( $path ) {
+		if ( is_readable( $path ) ) {
+			$mtime = filemtime( $path );
+			if ( $mtime ) {
+				return ALGOLIA_VERSION . '.' . $mtime;
+			}
+		}
+		return ALGOLIA_VERSION;
 	}
 
 	/**

--- a/includes/admin/class-algolia-admin.php
+++ b/includes/admin/class-algolia-admin.php
@@ -80,7 +80,7 @@ class Algolia_Admin {
 		wp_enqueue_style(
 			'algolia-admin',
 			plugin_dir_url( __FILE__ ) . 'css/algolia-admin.css',
-			array(),
+			[],
 			$this->asset_version( __DIR__ . '/css/algolia-admin.css' )
 		);
 	}
@@ -96,21 +96,21 @@ class Algolia_Admin {
 			'algolia-admin',
 			plugin_dir_url( __FILE__ ) . 'js/algolia-admin.js',
 			array( 'jquery', 'jquery-ui-sortable' ),
-			$this->asset_version( __DIR__ . '/js/algolia-admin.js' ),
+			ALGOLIA_VERSION,
 			false
 		);
 		wp_enqueue_script(
 			'algolia-admin-reindex-button',
 			plugin_dir_url( __FILE__ ) . 'js/reindex-button.js',
 			array( 'jquery' ),
-			$this->asset_version( __DIR__ . '/js/reindex-button.js' ),
+			ALGOLIA_VERSION,
 			false
 		);
 		wp_enqueue_script(
 			'algolia-admin-push-settings-button',
 			plugin_dir_url( __FILE__ ) . 'js/push-settings-button.js',
 			array( 'jquery' ),
-			$this->asset_version( __DIR__ . '/js/push-settings-button.js' ),
+			ALGOLIA_VERSION,
 			false
 		);
 	}
@@ -121,6 +121,8 @@ class Algolia_Admin {
 	 * Uses the file's modification time so edits to bundled CSS/JS bust the
 	 * browser cache without needing to bump ALGOLIA_VERSION. Falls back to the
 	 * plugin version if the file cannot be read.
+	 *
+	 * NOT USED BUT PRESERVING FOR THE MOMENT.
 	 *
 	 * @since 2.11.0
 	 *

--- a/includes/admin/css/algolia-admin.css
+++ b/includes/admin/css/algolia-admin.css
@@ -27,13 +27,341 @@
   cursor: pointer;
 }
 
-/* Native search page */
+/* Native search page (legacy fallback styles for non-card pages) */
 form .input-radio label {
   font-weight: bold;
 }
 form .radio-info {
   margin-bottom: 15px;
   padding-left: 25px;
+}
+
+/* Search Page settings — radio options rendered as cards */
+.algolia-settings-card .input-radio {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 720px;
+}
+
+.algolia-settings-card .algolia-radio-option {
+  background: var(--algolia-white);
+  border: 1px solid #dcdcde;
+  border-radius: 6px;
+  padding: 12px 16px;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.algolia-settings-card .algolia-radio-option:hover {
+  border-color: var(--algolia-blue-lighten);
+}
+
+.algolia-settings-card .algolia-radio-option:has(input[type="radio"]:checked) {
+  border-color: var(--algolia-blue);
+  box-shadow: 0 0 0 1px var(--algolia-blue);
+}
+
+.algolia-settings-card .algolia-radio-option > label {
+  align-items: center;
+  color: var(--algolia-dark-blue);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 14px;
+  font-weight: 600;
+  gap: 8px;
+  margin: 0;
+}
+
+.algolia-settings-card .algolia-radio-option > label input[type="radio"] {
+  margin: 0 6px 0 0;
+}
+
+.algolia-settings-card .algolia-radio-option .radio-info {
+  color: #3c434a;
+  font-size: 13px;
+  line-height: 1.55;
+  margin: 6px 0 0;
+  padding-left: 26px;
+}
+
+.algolia-settings-card .algolia-radio-option .radio-info code {
+  background: rgba(0, 0, 0, 0.06);
+  font-size: 12px;
+  padding: 1px 4px;
+}
+
+.algolia-radio-badge {
+  background: var(--algolia-blue);
+  border-radius: 999px;
+  color: var(--algolia-white);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  padding: 4px 10px;
+  text-transform: uppercase;
+}
+
+.algolia-radio-filename {
+  color: #50575e;
+  font-weight: 400;
+}
+
+.algolia-radio-filename code {
+  background: rgba(0, 0, 0, 0.06);
+  font-size: 12px;
+  padding: 1px 6px;
+}
+
+.algolia-radio-footnote {
+  align-items: flex-start;
+  color: #50575e;
+  display: flex;
+  font-size: 13px;
+  gap: 6px;
+  line-height: 1.55;
+  margin: 14px 0 0;
+}
+
+.algolia-radio-footnote .dashicons-info-outline {
+  color: var(--algolia-blue);
+  flex-shrink: 0;
+}
+
+/* Inline help disclosure used outside form-table cells (e.g. section intros) */
+.algolia-settings-card .algolia-field-help--inline {
+  margin: 4px 0 12px;
+  max-width: 720px;
+}
+
+/* Inline notice (replaces .error-message div on Search page empty state) */
+.algolia-settings-card .algolia-inline-notice.notice {
+  margin: 14px 0 0;
+}
+
+/* Suffix unit shown after small numeric inputs */
+.algolia-input-suffix {
+  color: #50575e;
+  font-size: 13px;
+  margin-left: 6px;
+}
+
+/* =========================================================
+   Autocomplete page — Autocomplete Config card list
+   ========================================================= */
+
+.algolia-settings-card .algolia-autocomplete-config {
+  margin: 6px 0 0;
+  max-width: 820px;
+}
+
+.algolia-autocomplete-config--empty {
+  background: var(--algolia-gray);
+  border: 1px dashed #c3c4c7;
+  border-radius: 6px;
+  color: #50575e;
+  padding: 18px 20px;
+}
+
+.algolia-autocomplete-config--empty p {
+  align-items: flex-start;
+  display: flex;
+  gap: 8px;
+  margin: 0;
+}
+
+.algolia-autocomplete-config--empty .dashicons-info-outline {
+  color: var(--algolia-blue);
+  flex-shrink: 0;
+}
+
+.algolia-autocomplete-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.algolia-autocomplete-row {
+  background: var(--algolia-white);
+  border: 1px solid #dcdcde;
+  border-radius: 6px;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: 28px 1fr auto;
+  padding: 16px 18px;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+}
+
+.algolia-autocomplete-row:hover {
+  border-color: var(--algolia-blue-lighten);
+}
+
+.algolia-autocomplete-row:has(input[type="checkbox"]:not(:checked)) {
+  background: #fafafa;
+  opacity: 0.78;
+}
+
+.algolia-autocomplete-row:has(input[type="checkbox"]:not(:checked)):hover {
+  opacity: 1;
+}
+
+/* Handle */
+.algolia-autocomplete-row__handle {
+  align-items: center;
+  color: #8c8f94;
+  cursor: grab;
+  display: flex;
+  height: 28px;
+  justify-content: center;
+  user-select: none;
+}
+
+.algolia-autocomplete-row__handle:hover {
+  color: var(--algolia-blue);
+}
+
+.algolia-autocomplete-row__handle:active {
+  cursor: grabbing;
+}
+
+.algolia-autocomplete-row__handle .dashicons {
+  font-size: 22px;
+  height: 22px;
+  width: 22px;
+}
+
+/* Main column */
+.algolia-autocomplete-row__main {
+  min-width: 0;
+}
+
+.algolia-autocomplete-row__header {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+}
+
+.algolia-autocomplete-row__toggle {
+  flex-shrink: 0;
+  margin: 0;
+}
+
+.algolia-autocomplete-row__toggle input[type="checkbox"] {
+  margin: 0;
+}
+
+.algolia-autocomplete-row__title {
+  color: var(--algolia-dark-blue);
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.3;
+  margin: 0;
+  overflow-wrap: anywhere;
+  padding: 0;
+}
+
+.algolia-autocomplete-row__meta {
+  color: #50575e;
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 12px;
+  gap: 12px;
+  margin: 6px 0 12px;
+}
+
+.algolia-autocomplete-row__meta code {
+  background: rgba(0, 0, 0, 0.06);
+  font-size: 12px;
+  padding: 1px 6px;
+}
+
+.algolia-autocomplete-row__debounce {
+  align-items: center;
+  background: rgba(0, 61, 255, 0.08);
+  border-radius: 999px;
+  color: var(--algolia-blue);
+  display: inline-flex;
+  font-weight: 500;
+  padding: 1px 8px;
+}
+
+/* Field row */
+.algolia-autocomplete-row__fields {
+  align-items: end;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 1fr 140px;
+}
+
+.algolia-autocomplete-row__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  min-width: 0;
+}
+
+.algolia-autocomplete-row__field-label {
+  color: #50575e;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.algolia-autocomplete-row__field input[type="text"] {
+  width: 100%;
+}
+
+.algolia-autocomplete-row__field input[type="number"] {
+  width: 100%;
+}
+
+/* Actions */
+.algolia-autocomplete-row__actions {
+  align-items: stretch;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  justify-content: flex-start;
+}
+
+.algolia-autocomplete-row__actions .button {
+  align-items: center;
+  display: inline-flex;
+  gap: 4px;
+  justify-content: center;
+  margin: 0;
+  white-space: nowrap;
+}
+
+.algolia-autocomplete-row__actions .button .dashicons {
+  font-size: 16px;
+  height: 16px;
+  width: 16px;
+}
+
+/* Sortable placeholder */
+.algolia-autocomplete-row__placeholder {
+  background: var(--algolia-gray);
+  border: 1px dashed var(--algolia-blue);
+  border-radius: 6px;
+  visibility: visible !important;
+}
+
+/* Smaller screens */
+@media screen and (max-width: 782px) {
+  .algolia-settings-card .algolia-autocomplete-row {
+    grid-template-columns: 28px 1fr;
+  }
+  .algolia-settings-card .algolia-autocomplete-row__actions {
+    flex-direction: row;
+    flex-wrap: wrap;
+    grid-column: 1 / -1;
+  }
+  .algolia-settings-card .algolia-autocomplete-row__fields {
+    grid-template-columns: 1fr;
+  }
 }
 
 #toplevel_page_algolia .algolia-pro-indicator {
@@ -135,50 +463,1070 @@ form .radio-info {
 .algolia-premium-wrap-block {
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  justify-content: space-between;
+  gap: 28px;
 }
 .algolia-premium-support-block {
-  text-align: center;
-}
-.algolia-premium-support-block.algolia-pro-block {
   text-align: left;
 }
-.wds-premium {
-  background: var(--algolia-blue);
-  color: var(--algolia-white);
-  padding: 10px;
-  border-radius: 9999px;
-  text-decoration: none;
+.algolia-premium-support-block > p {
+  color: #3c434a;
+  font-size: 14px;
+  line-height: 1.6;
+  margin: 0 0 20px;
+  max-width: 70ch;
 }
-.wds-premium:hover {
-  color: var(--algolia-white);
+
+.algolia-premium-support-list {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  margin: 0 0 24px;
 }
-.algolia-flex {
+.algolia-premium-support-list__item {
+  align-items: flex-start;
+  background: var(--algolia-gray);
+  border-radius: 6px;
+  display: flex;
+  gap: 12px;
+  padding: 16px 18px;
+}
+.algolia-premium-support-list__item .dashicons {
+  color: var(--algolia-blue);
+  flex-shrink: 0;
+  font-size: 22px;
+  height: 22px;
+  margin-top: 2px;
+  width: 22px;
+}
+.algolia-premium-support-list__item h3 {
+  color: var(--algolia-dark-blue);
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0 0 4px;
+}
+.algolia-premium-support-list__item p {
+  color: #3c434a;
+  font-size: 13px;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.algolia-premium-support-cta {
   align-items: center;
   display: flex;
   flex-wrap: wrap;
+  gap: 12px 18px;
+  margin-top: 4px;
+}
+.algolia-premium-support-cta__note {
+  color: #50575e;
+  font-size: 13px;
+  max-width: 50ch;
+}
+
+/* Full-width highlighted "WDS partnership" block */
+.algolia-premium-support-highlight {
+  align-items: flex-start;
+  background: linear-gradient(135deg, rgba(0, 61, 255, 0.04) 0%, rgba(0, 61, 255, 0.08) 100%);
+  border: 1px solid rgba(0, 61, 255, 0.18);
+  border-left: 4px solid var(--algolia-blue);
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 61, 255, 0.06);
+  display: flex;
+  gap: 22px;
+  margin: 4px 0 0;
+  padding: 24px 28px;
+  position: relative;
+}
+
+.algolia-premium-support-highlight::before {
+  background: radial-gradient(circle at 100% 0%, rgba(0, 61, 255, 0.08), transparent 60%);
+  border-radius: inherit;
+  content: "";
+  inset: 0;
+  pointer-events: none;
+  position: absolute;
+}
+
+.algolia-premium-support-highlight__icon {
+  align-items: center;
+  background: var(--algolia-blue);
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 61, 255, 0.25);
+  color: var(--algolia-white);
+  display: flex;
+  flex-shrink: 0;
+  height: 56px;
   justify-content: center;
+  width: 56px;
 }
-.algolia-flex-item {
-  padding: 5px 10px;
+
+.algolia-premium-support-highlight__icon .dashicons {
+  font-size: 28px;
+  height: 28px;
+  width: 28px;
 }
-.algolia-pro-flex-wrap {
+
+.algolia-premium-support-highlight__body {
+  flex: 1;
+  min-width: 0;
+  position: relative;
+  z-index: 1;
+}
+
+.algolia-premium-support-highlight__eyebrow {
+  color: var(--algolia-blue);
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  margin: 0 0 6px;
+  text-transform: uppercase;
+}
+
+.algolia-premium-support-highlight__title {
+  color: var(--algolia-dark-blue);
+  font-size: 19px;
+  font-weight: 700;
+  letter-spacing: -0.005em;
+  line-height: 1.3;
+  margin: 0 0 10px;
+  padding: 0;
+}
+
+.algolia-premium-support-highlight__lede {
+  color: #3c434a;
+  font-size: 14px;
+  line-height: 1.6;
+  margin: 0 0 16px;
+  max-width: 70ch;
+}
+
+.algolia-premium-support-highlight__cta {
+  align-items: center;
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
-  align-content: space-between;
+  gap: 12px 18px;
+}
+
+.algolia-premium-support-highlight__note {
+  color: #50575e;
+  font-size: 13px;
+  max-width: 50ch;
+}
+
+@media screen and (max-width: 600px) {
+  .algolia-premium-support-highlight {
+    flex-direction: column;
+    padding: 22px 20px;
+  }
+  .algolia-premium-support-highlight__icon {
+    height: 48px;
+    width: 48px;
+  }
+  .algolia-premium-support-highlight__icon .dashicons {
+    font-size: 24px;
+    height: 24px;
+    width: 24px;
+  }
+}
+
+.wds-premium {
+  align-items: center;
+  background: var(--algolia-blue);
+  border-radius: 999px;
+  color: var(--algolia-white);
+  display: inline-flex;
+  font-weight: 600;
+  gap: 6px;
+  padding: 10px 22px;
+  text-decoration: none;
+  transition: background-color 0.15s ease, transform 0.15s ease;
+}
+.wds-premium:hover,
+.wds-premium:focus {
+  background: var(--algolia-blue-lighten);
+  color: var(--algolia-white);
+  transform: translateY(-1px);
+}
+.wds-premium .dashicons {
+  font-size: 16px;
+  height: 16px;
+  width: 16px;
+}
+
+/* =========================================================
+   WP Search with Algolia Pro — upsell / CTA
+   ========================================================= */
+
+.algolia-pro-upsell {
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  margin: 28px 0 0;
+  overflow: hidden;
+}
+
+.algolia-pro-upsell__hero {
+  background: linear-gradient(135deg, #001a66 0%, var(--algolia-blue) 55%, #1a4dff 100%);
+  color: var(--algolia-white);
+  padding: 40px 36px 36px;
+  position: relative;
+}
+
+.algolia-pro-upsell__hero::after {
+  background:
+    radial-gradient(circle at 88% 14%, rgba(206, 255, 0, 0.18), transparent 50%),
+    radial-gradient(circle at 12% 82%, rgba(206, 255, 0, 0.12), transparent 48%);
+  content: "";
+  inset: 0;
+  pointer-events: none;
+  position: absolute;
+}
+
+.algolia-pro-upsell__hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.algolia-pro-upsell__hero-intro {
+  max-width: 720px;
+}
+
+.algolia-pro-upsell__eyebrow {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
   gap: 10px;
+  margin: 0 0 14px;
 }
-.algolia-pro-flex-item {
-  border-color: var(--algolia-blue);
-  border-radius: 15px;
+
+.algolia-pro-upsell__logomark {
+  align-items: center;
+  background: rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  color: var(--algolia-white);
+  display: inline-flex;
+  height: 32px;
+  justify-content: center;
+  width: 32px;
+}
+
+.algolia-pro-upsell__logomark svg {
+  display: block;
+  height: 18px;
+  width: 18px;
+}
+
+.algolia-pro-upsell__eyebrow-text {
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  opacity: 0.85;
+  text-transform: uppercase;
+}
+
+.algolia-pro-upsell__pro-pill {
+  background: var(--algolia-neon);
+  border-radius: 4px;
+  color: var(--algolia-dark-blue);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  padding: 3px 8px;
+}
+
+.algolia-pro-upsell__title {
+  color: var(--algolia-white);
+  font-size: 30px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1.15;
+  margin: 0 0 14px;
+  padding: 0;
+}
+
+.algolia-pro-upsell__lede {
+  color: rgba(255, 255, 255, 0.86);
+  font-size: 15px;
+  line-height: 1.55;
+  margin: 0 0 22px;
+  max-width: 60ch;
+}
+
+.algolia-pro-upsell__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 0 0 22px;
+}
+
+.algolia-pro-upsell__button-primary {
+  align-items: center;
+  background: var(--algolia-white);
+  border-radius: 6px;
+  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.15);
+  color: var(--algolia-dark-blue);
+  display: inline-flex;
+  font-size: 14px;
+  font-weight: 700;
+  gap: 8px;
+  padding: 12px 22px;
+  text-decoration: none;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
+}
+
+.algolia-pro-upsell__button-primary:hover,
+.algolia-pro-upsell__button-primary:focus {
+  background: var(--algolia-neon);
+  box-shadow: 0 4px 0 rgba(0, 0, 0, 0.18);
+  color: var(--algolia-dark-blue);
+  transform: translateY(-1px);
+}
+
+.algolia-pro-upsell__button-primary .dashicons {
+  font-size: 18px;
+  height: 18px;
+  width: 18px;
+}
+
+.algolia-pro-upsell__button-secondary {
+  align-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 6px;
+  color: var(--algolia-white);
+  display: inline-flex;
+  font-size: 14px;
+  font-weight: 600;
+  gap: 6px;
+  padding: 11px 20px;
+  text-decoration: none;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.algolia-pro-upsell__button-secondary:hover,
+.algolia-pro-upsell__button-secondary:focus {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: var(--algolia-white);
+  color: var(--algolia-white);
+}
+
+.algolia-pro-upsell__trust {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 22px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.algolia-pro-upsell__trust li {
+  align-items: center;
+  color: rgba(255, 255, 255, 0.85);
+  display: flex;
+  font-size: 13px;
+  gap: 6px;
+  margin: 0;
+}
+
+.algolia-pro-upsell__trust .dashicons {
+  background: var(--algolia-neon);
+  border-radius: 50%;
+  color: var(--algolia-dark-blue);
+  font-size: 14px;
+  height: 14px;
+  line-height: 14px;
+  text-align: center;
+  width: 14px;
+}
+
+/* AI sub-section — sits below the hero on a light background to break up the blue */
+
+.algolia-pro-upsell__ai {
+  background: var(--algolia-white);
+  display: flex;
+  gap: 22px;
+  padding: 32px 36px;
+  position: relative;
+}
+
+.algolia-pro-upsell__ai::before {
+  background: linear-gradient(90deg, transparent 0%, var(--algolia-neon) 20%, var(--algolia-neon) 80%, transparent 100%);
+  content: "";
+  height: 2px;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+.algolia-pro-upsell__ai-icon {
+  align-items: center;
+  background: linear-gradient(135deg, var(--algolia-neon) 0%, #b8e600 100%);
+  border-radius: 12px;
+  box-shadow:
+    0 0 0 1px rgba(206, 255, 0, 0.4),
+    0 8px 20px rgba(206, 255, 0, 0.25);
+  color: var(--algolia-dark-blue);
+  display: flex;
+  flex-shrink: 0;
+  height: 52px;
+  justify-content: center;
+  width: 52px;
+}
+
+.algolia-pro-upsell__ai-icon svg {
+  display: block;
+  height: 28px;
+  width: 28px;
+}
+
+.algolia-pro-upsell__ai-body {
   flex: 1;
-  width: 33%;
+  min-width: 0;
 }
-.algolia-pro-features {
-  padding-left: 15px;
+
+.algolia-pro-upsell__ai-eyebrow {
+  background: rgba(0, 61, 255, 0.08);
+  border: 1px solid rgba(0, 61, 255, 0.28);
+  border-radius: 4px;
+  color: var(--algolia-blue);
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  margin: 0 0 10px;
+  padding: 3px 10px;
+  text-transform: uppercase;
 }
-.algolia-pro-features li {
+
+.algolia-pro-upsell__ai-title {
+  color: var(--algolia-dark-blue);
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.005em;
+  line-height: 1.25;
+  margin: 0 0 10px;
+  padding: 0;
+}
+
+.algolia-pro-upsell__ai-lede {
+  color: #3c434a;
+  font-size: 14px;
+  line-height: 1.6;
+  margin: 0 0 16px;
+  max-width: 65ch;
+}
+
+.algolia-pro-upsell__ai-features {
+  display: grid;
+  gap: 6px 20px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.algolia-pro-upsell__ai-features li {
+  align-items: center;
+  color: var(--algolia-dark-blue);
+  display: flex;
+  font-size: 14px;
+  font-weight: 500;
+  gap: 8px;
+  margin: 0;
+}
+
+.algolia-pro-upsell__ai-features .dashicons-yes-alt {
+  color: var(--algolia-blue);
+  flex-shrink: 0;
+  font-size: 18px;
+  height: 18px;
+  width: 18px;
+}
+
+@media screen and (max-width: 782px) {
+  .algolia-pro-upsell__ai {
+    flex-direction: column;
+    gap: 16px;
+    padding: 26px 22px;
+  }
+  .algolia-pro-upsell__ai-features {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Subtle inline AI tag for individual feature bullets */
+
+.algolia-pro-upsell .algolia-pro-feature__ai-tag {
+  background: rgba(0, 61, 255, 0.08);
+  border: 1px solid rgba(0, 61, 255, 0.25);
+  border-radius: 3px;
+  color: var(--algolia-blue);
+  flex-shrink: 0;
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  line-height: 1.4;
+  margin-left: auto;
+  padding: 1px 6px;
+  text-transform: uppercase;
+}
+
+/* Feature cards */
+
+.algolia-pro-upsell__features {
+  background: var(--algolia-gray);
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(3, 1fr);
+  padding: 24px;
+}
+
+.algolia-pro-upsell .algolia-pro-feature {
+  background: var(--algolia-white);
+  border: 1px solid #dcdcde;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  padding: 22px;
+  position: relative;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.algolia-pro-upsell .algolia-pro-feature:hover {
+  border-color: var(--algolia-blue);
+  box-shadow: 0 6px 24px rgba(0, 61, 255, 0.12);
+  transform: translateY(-2px);
+}
+
+.algolia-pro-upsell .algolia-pro-feature__icon {
+  align-items: center;
+  background: rgba(0, 61, 255, 0.08);
+  border-radius: 10px;
+  color: var(--algolia-blue);
+  display: flex;
+  height: 44px;
+  justify-content: center;
+  margin: 0 0 14px;
+  width: 44px;
+}
+
+.algolia-pro-upsell .algolia-pro-feature__icon .dashicons {
+  font-size: 24px;
+  height: 24px;
+  width: 24px;
+}
+
+.algolia-pro-upsell .algolia-pro-feature__title {
+  color: var(--algolia-dark-blue);
+  font-size: 16px;
+  font-weight: 700;
+  margin: 0 0 6px;
+  padding: 0;
+}
+
+.algolia-pro-upsell .algolia-pro-feature__lede {
+  color: #3c434a;
+  font-size: 13px;
+  line-height: 1.55;
+  margin: 0 0 14px;
+}
+
+.algolia-pro-upsell .algolia-pro-feature__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.algolia-pro-upsell .algolia-pro-feature__list li {
+  align-items: flex-start;
+  color: #3c434a;
+  display: flex;
+  font-size: 13px;
+  gap: 8px;
+  line-height: 1.5;
+  margin: 0 0 8px;
+}
+
+.algolia-pro-upsell .algolia-pro-feature__list li:last-child {
+  margin-bottom: 0;
+}
+
+.algolia-pro-upsell .algolia-pro-feature__list .dashicons-yes-alt {
+  color: var(--algolia-blue);
+  flex-shrink: 0;
+  font-size: 16px;
+  height: 16px;
+  margin-top: 1px;
+  width: 16px;
+}
+
+/* Closing footer band */
+
+.algolia-pro-upsell__footer {
+  align-items: center;
+  background: var(--algolia-dark-blue);
+  color: var(--algolia-white);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px 24px;
+  justify-content: space-between;
+  padding: 22px 28px;
+}
+
+.algolia-pro-upsell__footer > div {
+  flex: 1 1 320px;
+  min-width: 0;
+}
+
+.algolia-pro-upsell__footer strong {
+  display: block;
+  font-size: 16px;
+  margin-bottom: 2px;
+}
+
+.algolia-pro-upsell__footer span {
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 13px;
+}
+
+.algolia-pro-upsell__button-primary--inverse {
+  background: var(--algolia-neon);
+  color: var(--algolia-dark-blue);
+}
+
+.algolia-pro-upsell__button-primary--inverse:hover,
+.algolia-pro-upsell__button-primary--inverse:focus {
+  background: var(--algolia-white);
+  color: var(--algolia-dark-blue);
+}
+
+/* Responsive */
+
+@media screen and (max-width: 960px) {
+  .algolia-pro-upsell__features {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .algolia-pro-upsell__title {
+    font-size: 26px;
+  }
+}
+
+@media screen and (max-width: 600px) {
+  .algolia-pro-upsell__hero {
+    padding: 28px 22px;
+  }
+  .algolia-pro-upsell__features {
+    grid-template-columns: 1fr;
+    padding: 18px;
+  }
+  .algolia-pro-upsell__title {
+    font-size: 22px;
+  }
+  .algolia-pro-upsell__footer {
+    padding: 18px 22px;
+  }
+}
+
+/* Settings page — extended help disclosure */
+.algolia-field-help {
+  margin-top: 6px;
+  max-width: 640px;
+}
+.algolia-field-help > summary {
+  color: var(--algolia-blue);
+  cursor: pointer;
+  display: inline-block;
+  font-size: 13px;
+  font-weight: 500;
+  list-style: none;
+  padding: 2px 0;
+}
+.algolia-field-help > summary::-webkit-details-marker {
+  display: none;
+}
+.algolia-field-help > summary::before {
+  content: "\f139";
+  font-family: dashicons;
+  margin-right: 4px;
+  vertical-align: text-bottom;
+}
+.algolia-field-help[open] > summary::before {
+  content: "\f140";
+}
+.algolia-field-help > summary:hover {
+  color: var(--algolia-blue-lighten);
+}
+.algolia-field-help > summary:focus-visible {
+  outline: 2px solid var(--algolia-blue);
+  outline-offset: 2px;
+}
+.algolia-field-help__body {
+  background: var(--algolia-gray);
+  border-left: 3px solid var(--algolia-blue);
+  border-radius: 2px;
+  margin-top: 6px;
+  padding: 10px 14px;
+}
+.algolia-field-help__body p {
+  margin: 0 0 8px;
+}
+.algolia-field-help__body p:last-child {
+  margin-bottom: 0;
+}
+.algolia-field-help__body ul {
   list-style: disc;
+  margin: 0 0 8px 18px;
+}
+.algolia-field-help__body ul:last-child {
+  margin-bottom: 0;
+}
+.algolia-field-help__body li {
+  margin-bottom: 4px;
+}
+.algolia-field-help__body li:last-child {
+  margin-bottom: 0;
+}
+.algolia-field-help__body code {
+  background: rgba(0, 0, 0, 0.06);
+  font-size: 12px;
+  padding: 1px 4px;
+}
+.algolia-field-help__body .dashicons-external {
+  font-size: 14px;
+  height: 14px;
+  vertical-align: middle;
+  width: 14px;
+}
+
+/* Settings page — wp-config locked field notice */
+.algolia-field-locked {
+  align-items: flex-start;
+  background: #fff8e5;
+  border-left: 3px solid #dba617;
+  color: #50575e;
+  display: flex;
+  font-size: 13px;
+  gap: 6px;
+  margin: 6px 0 0;
+  max-width: 640px;
+  padding: 8px 12px;
+}
+.algolia-field-locked .dashicons-lock {
+  color: #dba617;
+  flex-shrink: 0;
+}
+.algolia-field-locked code {
+  background: rgba(0, 0, 0, 0.06);
+  font-size: 12px;
+  padding: 1px 4px;
+}
+
+/* =========================================================
+   Settings page — branded layout
+   Scoped to .algolia-settings-page so other admin pages are unaffected.
+   ========================================================= */
+
+.algolia-settings-page {
+  max-width: 960px;
+}
+
+.algolia-settings-page > h1.wp-heading-inline,
+.algolia-settings-page > h1:not(.algolia-settings-header__title) {
+  /* Hide the legacy bare <h1> when we render our own header. */
+  display: none;
+}
+
+/* Header banner -------------------------------------------- */
+
+.algolia-settings-header {
+  align-items: center;
+  background: var(--algolia-white);
+  border: 1px solid #dcdcde;
+  border-left: 4px solid var(--algolia-blue);
+  border-radius: 6px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  display: flex;
+  gap: 20px;
+  margin: 16px 0 24px;
+  padding: 22px 28px;
+}
+
+.algolia-settings-header__logo {
+  align-items: center;
+  background: var(--algolia-gray);
+  border-radius: 12px;
+  color: var(--algolia-blue);
+  display: flex;
+  flex-shrink: 0;
+  height: 64px;
+  justify-content: center;
+  width: 64px;
+}
+
+.algolia-settings-header__logo svg {
+  display: block;
+  height: 36px;
+  width: 36px;
+}
+
+.algolia-settings-header__text {
+  flex: 1;
+  min-width: 0;
+}
+
+.algolia-settings-header__title {
+  color: var(--algolia-dark-blue);
+  font-size: 22px;
+  font-weight: 600;
+  line-height: 1.25;
+  margin: 0 0 4px;
+  padding: 0;
+}
+
+.algolia-settings-header__subtitle {
+  color: #50575e;
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 0;
+  max-width: 70ch;
+}
+
+.algolia-settings-header__actions {
+  display: flex;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.algolia-settings-header__actions .button {
+  margin: 0;
+}
+
+.algolia-settings-header__actions .button-primary {
+  background: var(--algolia-blue);
+  border-color: var(--algolia-blue);
+  border-radius: 4px;
+  font-weight: 500;
+  text-shadow: none;
+}
+
+.algolia-settings-header__actions .button-primary:hover,
+.algolia-settings-header__actions .button-primary:focus {
+  background: var(--algolia-blue-lighten);
+  border-color: var(--algolia-blue-lighten);
+}
+
+/* Card --------------------------------------------------- */
+
+.algolia-settings-card {
+  background: var(--algolia-white);
+  border: 1px solid #dcdcde;
+  border-radius: 6px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  padding: 8px 28px 22px;
+}
+
+.algolia-settings-card form {
+  margin: 0;
+}
+
+/* Section headings inside form-driven cards */
+.algolia-settings-card form h2 {
+  border-bottom: 1px solid #f0f0f1;
+  color: var(--algolia-dark-blue);
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  margin: 28px 0 0;
+  padding: 0 0 8px 12px;
+  position: relative;
+  text-transform: uppercase;
+}
+
+.algolia-settings-card form h2::before {
+  background: var(--algolia-blue);
+  border-radius: 2px;
+  content: "";
+  height: 14px;
+  left: 0;
+  position: absolute;
+  top: 4px;
+  width: 3px;
+}
+
+.algolia-settings-card form h2:first-of-type {
+  margin-top: 14px;
+}
+
+/* Section intro paragraphs (rendered by section callbacks) */
+.algolia-settings-card form h2 + p,
+.algolia-settings-card form h2 ~ p {
+  color: #3c434a;
+  font-size: 14px;
+  margin: 10px 0;
+}
+
+.algolia-settings-card form a {
+  color: var(--algolia-blue);
+  text-decoration: none;
+}
+
+.algolia-settings-card form a:hover {
+  color: var(--algolia-blue-lighten);
+  text-decoration: underline;
+}
+
+/* Form table polish */
+.algolia-settings-card .form-table {
+  margin-top: 6px;
+}
+
+.algolia-settings-card .form-table th {
+  color: var(--algolia-dark-blue);
+  font-weight: 600;
+  padding: 18px 10px 18px 0;
+  width: 220px;
+}
+
+.algolia-settings-card .form-table td {
+  padding: 16px 10px;
+}
+
+.algolia-settings-card .form-table input[type="text"],
+.algolia-settings-card .form-table input[type="password"] {
+  border-radius: 4px;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.algolia-settings-card .form-table input[type="text"]:focus,
+.algolia-settings-card .form-table input[type="password"]:focus {
+  border-color: var(--algolia-blue);
+  box-shadow: 0 0 0 1px var(--algolia-blue);
+  outline: 0;
+}
+
+.algolia-settings-card .form-table input[type="text"][disabled],
+.algolia-settings-card .form-table input[type="password"][disabled] {
+  background: var(--algolia-gray);
+  color: #646970;
+}
+
+.algolia-settings-card .form-table input[type="checkbox"]:focus {
+  border-color: var(--algolia-blue);
+  box-shadow: 0 0 0 1px var(--algolia-blue);
+  outline: 0;
+}
+
+.algolia-settings-card .form-table input[type="checkbox"]:checked::before {
+  color: var(--algolia-blue);
+}
+
+/* Submit button — branded primary */
+.algolia-settings-card .submit {
+  border-top: 1px solid #f0f0f1;
+  margin: 18px 0 0;
+  padding: 18px 0 4px;
+}
+
+.algolia-settings-card .button-primary {
+  background: var(--algolia-blue);
+  border-color: var(--algolia-blue);
+  border-radius: 4px;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
+  font-weight: 500;
+  padding: 4px 18px;
+  text-shadow: none;
+}
+
+.algolia-settings-card .button-primary:hover,
+.algolia-settings-card .button-primary:focus {
+  background: var(--algolia-blue-lighten);
+  border-color: var(--algolia-blue-lighten);
+  color: var(--algolia-white);
+}
+
+.algolia-settings-card .button-primary:focus {
+  box-shadow: 0 0 0 2px var(--algolia-white), 0 0 0 4px var(--algolia-blue);
+}
+
+/* Tighten the gap between the input row and the help disclosure */
+.algolia-settings-card .form-table td > .description:first-of-type {
+  margin-top: 8px;
+}
+
+/* Premium Support — adjust inside the branded card */
+.algolia-settings-card .algolia-premium-wrap-block {
+  margin-top: 14px;
+}
+
+.algolia-settings-card .algolia-premium-support-block h2 {
+  color: var(--algolia-dark-blue);
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0 0 8px;
+}
+
+.algolia-settings-card .algolia-premium-support-block h2 a {
+  color: var(--algolia-blue);
+  text-decoration: none;
+}
+
+.algolia-settings-card .algolia-premium-support-block h2 a:hover {
+  color: var(--algolia-blue-lighten);
+  text-decoration: underline;
+}
+
+.algolia-settings-card .algolia-pro-flex-item.card {
+  background: var(--algolia-white);
+  border: 1px solid #dcdcde;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  margin: 0;
+  min-width: 0;
+  padding: 18px 20px;
+}
+
+.algolia-settings-card .algolia-pro-flex-item h3 {
+  color: var(--algolia-dark-blue);
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0 0 10px;
+}
+
+.algolia-settings-card .wds-premium {
+  display: inline-block;
+  padding: 8px 22px;
+  transition: background-color 0.15s ease;
+}
+
+.algolia-settings-card .wds-premium:hover {
+  background: var(--algolia-blue-lighten);
+}
+
+/* Smaller screens */
+@media screen and (max-width: 782px) {
+  .algolia-settings-header {
+    flex-direction: column;
+    text-align: center;
+  }
+  .algolia-settings-header__logo {
+    margin: 0 auto;
+  }
+  .algolia-settings-header__actions {
+    justify-content: center;
+    width: 100%;
+  }
+  .algolia-settings-card {
+    padding: 8px 16px 16px;
+  }
+  .algolia-settings-card .form-table th {
+    padding-bottom: 0;
+    width: auto;
+  }
+  .algolia-settings-card .algolia-pro-flex-item {
+    flex: 1 1 100%;
+    width: 100%;
+  }
 }

--- a/includes/admin/css/algolia-admin.css
+++ b/includes/admin/css/algolia-admin.css
@@ -239,6 +239,7 @@ form .radio-info {
   align-items: center;
   display: flex;
   gap: 12px;
+  margin-bottom: 12px;
 }
 
 .algolia-autocomplete-row__toggle {
@@ -323,7 +324,7 @@ form .radio-info {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  justify-content: flex-start;
+  justify-content: flex-end;
 }
 
 .algolia-autocomplete-row__actions .button {
@@ -339,6 +340,7 @@ form .radio-info {
   font-size: 16px;
   height: 16px;
   width: 16px;
+  line-height: initial;
 }
 
 /* Sortable placeholder */

--- a/includes/admin/css/algolia-admin.css
+++ b/includes/admin/css/algolia-admin.css
@@ -1096,10 +1096,13 @@ form .radio-info {
   color: var(--algolia-dark-blue);
 }
 
+.algolia-pro-upsell__button-primary--inverse .dashicons-arrow-right-alt {
+  color: var(--algolia-dark-blue);
+}
+
 .algolia-pro-upsell__button-primary--inverse:hover,
 .algolia-pro-upsell__button-primary--inverse:focus {
   background: var(--algolia-white);
-  color: var(--algolia-dark-blue);
 }
 
 /* Responsive */

--- a/includes/admin/js/algolia-admin.js
+++ b/includes/admin/js/algolia-admin.js
@@ -5,12 +5,24 @@
 		function() {
 
 			function updateAutocompletePositions () {
-				$( '.table-autocomplete .position-input' ).each(
+				$( '.algolia-autocomplete-list .position-input, .table-autocomplete .position-input' ).each(
 					function(index, value) {
 						$( value ).val( index );
 					}
 				);
 			}
+			$( '.algolia-autocomplete-list' ).sortable(
+				{
+					handle: '.algolia-autocomplete-row__handle',
+					placeholder: 'algolia-autocomplete-row__placeholder',
+					forcePlaceholderSize: true,
+					tolerance: 'pointer',
+					update: function() {
+						updateAutocompletePositions();
+					}
+				}
+			);
+			// Backwards compatibility for any custom code still rendering the legacy table.
 			$( '.table-autocomplete tbody' ).sortable(
 				{
 					update: function() {

--- a/includes/admin/partials/admin-header.php
+++ b/includes/admin/partials/admin-header.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Branded admin page header partial.
+ *
+ * Expects two variables in scope from the including file:
+ *
+ * - string $algolia_header_subtitle One-line subtitle shown under the page title.
+ * - string $algolia_header_actions  Optional raw HTML rendered on the right of the
+ *                                   header (e.g. action buttons). Already escaped
+ *                                   by the caller.
+ *
+ * @author  WebDevStudios <contact@webdevstudios.com>
+ * @since   2.11.0
+ *
+ * @package WebDevStudios\WPSWA
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$algolia_header_subtitle = isset( $algolia_header_subtitle ) ? (string) $algolia_header_subtitle : '';
+$algolia_header_actions  = isset( $algolia_header_actions ) ? (string) $algolia_header_actions : '';
+?>
+<header class="algolia-settings-header">
+	<div class="algolia-settings-header__logo" aria-hidden="true">
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500.34" focusable="false"><path fill="currentColor" d="M250,0C113.38,0,2,110.16,.03,246.32c-2,138.29,110.19,252.87,248.49,253.67,42.71,.25,83.85-10.2,120.38-30.05,3.56-1.93,4.11-6.83,1.08-9.52l-23.39-20.74c-4.75-4.22-11.52-5.41-17.37-2.92-25.5,10.85-53.21,16.39-81.76,16.04-111.75-1.37-202.04-94.35-200.26-206.1,1.76-110.33,92.06-199.55,202.8-199.55h202.83V407.68l-115.08-102.25c-3.72-3.31-9.43-2.66-12.43,1.31-18.47,24.46-48.56,39.67-81.98,37.36-46.36-3.2-83.92-40.52-87.4-86.86-4.15-55.28,39.65-101.58,94.07-101.58,49.21,0,89.74,37.88,93.97,86.01,.38,4.28,2.31,8.28,5.53,11.13l29.97,26.57c3.4,3.01,8.8,1.17,9.63-3.3,2.16-11.55,2.92-23.6,2.07-35.95-4.83-70.39-61.84-127.01-132.26-131.35-80.73-4.98-148.23,58.18-150.37,137.35-2.09,77.15,61.12,143.66,138.28,145.36,32.21,.71,62.07-9.42,86.2-26.97l150.36,133.29c6.45,5.71,16.62,1.14,16.62-7.48V9.49C500,4.25,495.75,0,490.51,0H250Z"/></svg>
+	</div>
+	<div class="algolia-settings-header__text">
+		<h1 class="algolia-settings-header__title"><?php echo esc_html( get_admin_page_title() ); ?></h1>
+		<?php if ( '' !== $algolia_header_subtitle ) : ?>
+			<p class="algolia-settings-header__subtitle"><?php echo esc_html( $algolia_header_subtitle ); ?></p>
+		<?php endif; ?>
+	</div>
+	<?php if ( '' !== $algolia_header_actions ) : ?>
+		<div class="algolia-settings-header__actions">
+			<?php
+			// Caller is responsible for escaping. Allow standard WP button markup.
+			echo wp_kses(
+				$algolia_header_actions,
+				array(
+					'button' => array(
+						'type'        => array(),
+						'class'       => array(),
+						'data-index'  => array(),
+						'data-action' => array(),
+						'aria-label'  => array(),
+					),
+					'a'      => array(
+						'href'   => array(),
+						'class'  => array(),
+						'target' => array(),
+						'rel'    => array(),
+					),
+					'span'   => array(
+						'class' => array(),
+					),
+				)
+			);
+			?>
+		</div>
+	<?php endif; ?>
+</header>

--- a/includes/admin/partials/form-options-premium-support.php
+++ b/includes/admin/partials/form-options-premium-support.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Form options admin template partial.
+ * Premium Support admin template partial.
  *
  * @author  WebDevStudios <contact@webdevstudios.com>
  * @since   2.5.0
@@ -10,72 +10,251 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
+
+$algolia_header_subtitle = __( 'Get hands-on help from the team behind WP Search with Algolia, and explore the Pro add-on.', 'wp-search-with-algolia' );
+$algolia_header_actions  = '';
+
+$wds_url = 'https://webdevstudios.com/contact/';
+$pro_url = 'https://pluginize.com/plugins/wp-search-with-algolia-pro/';
 ?>
 
-<div class="wrap about-wrap">
-	<h1>
-		<?php echo esc_html( get_admin_page_title() ); ?>
-	</h1>
-	<div class="algolia-premium-wrap-block">
-		<div class="algolia-premium-support-block">
-			<p>
-				<?php esc_html_e( 'Thank you for using WP Search with Algolia to enhance your website\'s search experience. We are happy to have you as a user.', 'wp-search-with-algolia' ); ?>
-			</p>
-		</div>
+<div class="wrap algolia-settings-page">
+	<?php require dirname( __FILE__ ) . '/admin-header.php'; ?>
 
-		<div class="algolia-premium-support-block">
-			<h2><?php esc_html_e( 'Seeking help?', 'wp-search-with-algolia' ); ?></h2>
-			<p>
-				<?php esc_html_e( 'Our premium support and integration services ensure a seamless implementation of Algolia into your WordPress site. Whether you’re running a blog, eCommerce platform, or enterprise-level application, we’ll handle every detail—from setup and configuration to advanced customizations that match your unique needs.', 'wp-search-with-algolia' ); ?>
-			</p>
-			<p>
-				<?php esc_html_e( 'At WebDevStudios, we’re not just delivering tools—we’re empowering you with a scalable, high-performing search experience. Ready to elevate your WordPress website? Let’s make it happen!', 'wp-search-with-algolia' ); ?>
-			</p>
-		</div>
+	<div class="algolia-settings-card">
+		<div class="algolia-premium-wrap-block">
 
-		<div class="algolia-premium-support-block">
-			<h2><?php esc_html_e( 'Ready to work with us?', 'wp-search-with-algolia' ); ?></h2>
-			<div class="algolia-flex">
-				<div class="algolia-flex-item">
-					<p><a class="wds-premium" href="https://webdevstudios.com/contact/" target="_blank" rel="noopener"><?php esc_html_e( 'Contact WebDevStudios', 'wp-search-with-algolia' ); ?></a>
-					</p>
+			<div class="algolia-premium-support-block">
+				<h2><?php esc_html_e( 'Premium Support &amp; Integration Services', 'wp-search-with-algolia' ); ?></h2>
+				<p>
+					<?php esc_html_e( 'Going beyond what the free plugin offers? WebDevStudios, the team behind WP Search with Algolia, can help you ship a polished, production-ready Algolia search experience without burning your own engineering hours on it.', 'wp-search-with-algolia' ); ?>
+				</p>
+
+				<div class="algolia-premium-support-list">
+					<div class="algolia-premium-support-list__item">
+						<span class="dashicons dashicons-admin-tools" aria-hidden="true"></span>
+						<div>
+							<h3><?php esc_html_e( 'Setup &amp; configuration', 'wp-search-with-algolia' ); ?></h3>
+							<p><?php esc_html_e( 'Account provisioning, key management, index strategy, ranking tuning, and autocomplete or results-page wiring tailored to your content model.', 'wp-search-with-algolia' ); ?></p>
+						</div>
+					</div>
+
+					<div class="algolia-premium-support-list__item">
+						<span class="dashicons dashicons-screenoptions" aria-hidden="true"></span>
+						<div>
+							<h3><?php esc_html_e( 'Custom integrations', 'wp-search-with-algolia' ); ?></h3>
+							<p><?php esc_html_e( 'Custom post types, ACF fields, faceted filters, multi-language sites, headless front ends. We build the integration to fit your site.', 'wp-search-with-algolia' ); ?></p>
+						</div>
+					</div>
+
+					<div class="algolia-premium-support-list__item">
+						<span class="dashicons dashicons-performance" aria-hidden="true"></span>
+						<div>
+							<h3><?php esc_html_e( 'Scale &amp; performance', 'wp-search-with-algolia' ); ?></h3>
+							<p><?php esc_html_e( 'Multisite networks, large catalogs, and high-traffic eCommerce stores. We profile bottlenecks, optimize indexing, and design for the way your visitors actually search.', 'wp-search-with-algolia' ); ?></p>
+						</div>
+					</div>
 				</div>
+
+				<aside class="algolia-premium-support-highlight" aria-labelledby="algolia-wds-partnership-heading">
+					<div class="algolia-premium-support-highlight__icon" aria-hidden="true">
+						<span class="dashicons dashicons-sos"></span>
+					</div>
+					<div class="algolia-premium-support-highlight__body">
+						<span class="algolia-premium-support-highlight__eyebrow"><?php esc_html_e( 'A long-term WordPress partner', 'wp-search-with-algolia' ); ?></span>
+						<h3 id="algolia-wds-partnership-heading" class="algolia-premium-support-highlight__title">
+							<?php esc_html_e( 'WebDevStudios is a premier WordPress agency. We can do anything with WordPress.', 'wp-search-with-algolia' ); ?>
+						</h3>
+						<p class="algolia-premium-support-highlight__lede">
+							<?php esc_html_e( 'Beyond Algolia search, our team designs, builds, and operates every part of your WordPress site: eCommerce, headless front ends, multisite networks, custom plugin and block development, content migrations, performance work, and ongoing maintenance retainers. Whatever your roadmap calls for, we have shipped it before and can ship it for you.', 'wp-search-with-algolia' ); ?>
+						</p>
+						<div class="algolia-premium-support-highlight__cta">
+							<a class="wds-premium" href="<?php echo esc_url( $wds_url ); ?>" target="_blank" rel="noopener noreferrer">
+								<?php esc_html_e( 'Talk to WebDevStudios', 'wp-search-with-algolia' ); ?>
+								<span class="dashicons dashicons-arrow-right-alt" aria-hidden="true"></span>
+							</a>
+							<span class="algolia-premium-support-highlight__note">
+								<?php esc_html_e( 'Free, no-pressure scoping call. We will tell you honestly whether you need our help or just need to flip a setting.', 'wp-search-with-algolia' ); ?>
+							</span>
+						</div>
+					</div>
+				</aside>
 			</div>
-		</div>
 
-		<div class="algolia-premium-support-block algolia-pro-block">
-			<h2><a href="https://pluginize.com/plugins/wp-search-with-algolia-pro/" target="_blank"><?php esc_html_e( 'WP Search with Algolia Pro', 'wp-search-with-algolia' ); ?></a></h2>
-			<div class="algolia-pro-flex-wrap">
-				<div class="algolia-pro-flex-item card">
-					<h3><?php esc_html_e( 'Multisite Indexing', 'wp-search-with-algolia' ); ?></h3>
-					<ul class="algolia-pro-features">
-						<li><?php esc_html_e( 'Multisite network indexing into a single search index to provide a global Algolia-powered search experience.', 'wp-search-with-algolia' ); ?></li>
-						<li><?php esc_html_e( 'Easily search all sites in your Multisite network with a single search experience!', 'wp-search-with-algolia' ); ?></li>
-					</ul>
-				</div>
-				<div class="algolia-pro-flex-item card">
-					<h3><?php esc_html_e( 'WooCommerce Support', 'wp-search-with-algolia' ); ?></h3>
-					<ul class="algolia-pro-features">
-						<li><?php esc_html_e( 'Index product SKUs, prices, short descriptions and product dimensions/weight for display.', 'wp-search-with-algolia' ); ?>'</li>
-						<li><?php esc_html_e( 'Index product total sales ratings for relevance.', 'wp-search-with-algolia' ); ?></li>
-						<li><?php esc_html_e( 'Index product total and average ratings for relevance.', 'wp-search-with-algolia' ); ?></li>
-						<li><?php esc_html_e( 'Control whether or not sold out products are indexed.', 'wp-search-with-algolia' ); ?></li>
-						<li><?php esc_html_e( 'Control whether or not "shop only" or "hidden" products are indexed.', 'wp-search-with-algolia' ); ?></li>
-						<li><?php esc_html_e( 'Amend indexing to only include WooCommerce products.', 'wp-search-with-algolia' ); ?></li>
-					</ul>
-				</div>
-				<div class="algolia-pro-flex-item card">
-					<h3><?php esc_html_e( 'Search Engine Optimization', 'wp-search-with-algolia' ); ?></h3>
-					<ul class="algolia-pro-features">
-						<li><?php esc_html_e( 'Fine tune indexing on selected pieces of content', 'wp-search-with-algolia' ); ?></li>
-						<li><?php esc_html_e( 'Yoast SEO', 'wp-search-with-algolia' ); ?></li>
-						<li><?php esc_html_e( 'All in One SEO', 'wp-search-with-algolia' ); ?></li>
-						<li><?php esc_html_e( 'Rank Math SEO', 'wp-search-with-algolia' ); ?></li>
-						<li><?php esc_html_e( 'SEOPress', 'wp-search-with-algolia' ); ?></li>
-						<li><?php esc_html_e( 'The SEO Framework Support', 'wp-search-with-algolia' ); ?></li>
-					</ul>
-				</div>
-			</div>
 		</div>
 	</div>
+
+	<aside class="algolia-pro-upsell" aria-labelledby="algolia-pro-upsell-heading">
+		<div class="algolia-pro-upsell__hero">
+			<div class="algolia-pro-upsell__hero-intro">
+				<div class="algolia-pro-upsell__eyebrow">
+					<span class="algolia-pro-upsell__logomark" aria-hidden="true">
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500.34" focusable="false"><path fill="currentColor" d="M250,0C113.38,0,2,110.16,.03,246.32c-2,138.29,110.19,252.87,248.49,253.67,42.71,.25,83.85-10.2,120.38-30.05,3.56-1.93,4.11-6.83,1.08-9.52l-23.39-20.74c-4.75-4.22-11.52-5.41-17.37-2.92-25.5,10.85-53.21,16.39-81.76,16.04-111.75-1.37-202.04-94.35-200.26-206.1,1.76-110.33,92.06-199.55,202.8-199.55h202.83V407.68l-115.08-102.25c-3.72-3.31-9.43-2.66-12.43,1.31-18.47,24.46-48.56,39.67-81.98,37.36-46.36-3.2-83.92-40.52-87.4-86.86-4.15-55.28,39.65-101.58,94.07-101.58,49.21,0,89.74,37.88,93.97,86.01,.38,4.28,2.31,8.28,5.53,11.13l29.97,26.57c3.4,3.01,8.8,1.17,9.63-3.3,2.16-11.55,2.92-23.6,2.07-35.95-4.83-70.39-61.84-127.01-132.26-131.35-80.73-4.98-148.23,58.18-150.37,137.35-2.09,77.15,61.12,143.66,138.28,145.36,32.21,.71,62.07-9.42,86.2-26.97l150.36,133.29c6.45,5.71,16.62,1.14,16.62-7.48V9.49C500,4.25,495.75,0,490.51,0H250Z"/></svg>
+					</span>
+					<span class="algolia-pro-upsell__eyebrow-text"><?php esc_html_e( 'WP Search with Algolia', 'wp-search-with-algolia' ); ?></span>
+					<span class="algolia-pro-upsell__pro-pill"><?php esc_html_e( 'PRO', 'wp-search-with-algolia' ); ?></span>
+				</div>
+
+				<h2 id="algolia-pro-upsell-heading" class="algolia-pro-upsell__title">
+					<?php esc_html_e( 'Take WordPress search further.', 'wp-search-with-algolia' ); ?>
+				</h2>
+
+				<p class="algolia-pro-upsell__lede">
+					<?php esc_html_e( 'Multisite network search, deep WooCommerce indexing, and turnkey integrations with the SEO plugins your site already runs on, without writing a line of code.', 'wp-search-with-algolia' ); ?>
+				</p>
+
+				<div class="algolia-pro-upsell__actions">
+					<a class="algolia-pro-upsell__button-primary" href="<?php echo esc_url( $pro_url ); ?>" target="_blank" rel="noopener noreferrer">
+						<?php esc_html_e( 'Get WP Search with Algolia Pro', 'wp-search-with-algolia' ); ?>
+						<span class="dashicons dashicons-arrow-right-alt" aria-hidden="true"></span>
+					</a>
+					<a class="algolia-pro-upsell__button-secondary" href="<?php echo esc_url( $pro_url ); ?>#features" target="_blank" rel="noopener noreferrer">
+						<?php esc_html_e( 'See all features', 'wp-search-with-algolia' ); ?>
+					</a>
+				</div>
+
+				<ul class="algolia-pro-upsell__trust">
+					<li>
+						<span class="dashicons dashicons-yes" aria-hidden="true"></span>
+						<?php esc_html_e( 'Built by the team behind WP Search with Algolia', 'wp-search-with-algolia' ); ?>
+					</li>
+					<li>
+						<span class="dashicons dashicons-yes" aria-hidden="true"></span>
+						<?php esc_html_e( 'No-code configuration that works with your existing theme', 'wp-search-with-algolia' ); ?>
+					</li>
+					<li>
+						<span class="dashicons dashicons-yes" aria-hidden="true"></span>
+						<?php esc_html_e( 'Backed by WebDevStudios premium support', 'wp-search-with-algolia' ); ?>
+					</li>
+				</ul>
+			</div>
+		</div>
+
+		<section class="algolia-pro-upsell__ai" aria-labelledby="algolia-pro-upsell-ai-heading">
+			<div class="algolia-pro-upsell__ai-icon" aria-hidden="true">
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" focusable="false">
+					<path d="M12 1.5l1.6 6.9 6.9 1.6-6.9 1.6L12 18.5l-1.6-6.9-6.9-1.6 6.9-1.6z"/>
+					<path d="M19.2 14.4l.7 2.7 2.7.7-2.7.7-.7 2.7-.7-2.7-2.7-.7 2.7-.7z" opacity="0.65"/>
+					<path d="M4.6 2.4l.5 2 2 .5-2 .5-.5 2-.5-2-2-.5 2-.5z" opacity="0.55"/>
+				</svg>
+			</div>
+			<div class="algolia-pro-upsell__ai-body">
+				<span class="algolia-pro-upsell__ai-eyebrow"><?php esc_html_e( 'Advanced AI', 'wp-search-with-algolia' ); ?></span>
+				<h3 id="algolia-pro-upsell-ai-heading" class="algolia-pro-upsell__ai-title">
+					<?php esc_html_e( 'Advanced Algolia AI Support', 'wp-search-with-algolia' ); ?>
+				</h3>
+				<p class="algolia-pro-upsell__ai-lede">
+					<?php esc_html_e( 'WP Search with Algolia Pro turns on Algolia Insights tracking, so your site collects the interaction data Algolia\'s advanced AI features need to work. Real-time events stream to Algolia for smarter personalization and product recommendations.', 'wp-search-with-algolia' ); ?>
+				</p>
+				<ul class="algolia-pro-upsell__ai-features">
+					<li>
+						<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
+						<?php esc_html_e( 'Semantic search', 'wp-search-with-algolia' ); ?>
+					</li>
+					<li>
+						<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
+						<?php esc_html_e( 'AI re-ranking', 'wp-search-with-algolia' ); ?>
+					</li>
+					<li>
+						<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
+						<?php esc_html_e( 'Shopping guides', 'wp-search-with-algolia' ); ?>
+					</li>
+					<li>
+						<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
+						<?php esc_html_e( 'Dynamic personalization', 'wp-search-with-algolia' ); ?>
+					</li>
+				</ul>
+			</div>
+		</section>
+
+		<div class="algolia-pro-upsell__features">
+			<article class="algolia-pro-feature">
+				<div class="algolia-pro-feature__icon" aria-hidden="true">
+					<span class="dashicons dashicons-networking"></span>
+				</div>
+				<h3 class="algolia-pro-feature__title"><?php esc_html_e( 'Multisite Indexing', 'wp-search-with-algolia' ); ?></h3>
+				<p class="algolia-pro-feature__lede"><?php esc_html_e( 'One search index for an entire network. Visitors search every site in the network from a single box.', 'wp-search-with-algolia' ); ?></p>
+				<ul class="algolia-pro-feature__list">
+					<li>
+						<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
+						<?php esc_html_e( 'Aggregate every subsite into one Algolia index for a unified, network-wide search experience.', 'wp-search-with-algolia' ); ?>
+					</li>
+					<li>
+						<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
+						<?php esc_html_e( 'Per-site filters and badges so visitors can drill down to a specific subsite when they need to.', 'wp-search-with-algolia' ); ?>
+					</li>
+				</ul>
+			</article>
+
+			<article class="algolia-pro-feature">
+				<div class="algolia-pro-feature__icon" aria-hidden="true">
+					<span class="dashicons dashicons-cart"></span>
+				</div>
+				<h3 class="algolia-pro-feature__title"><?php esc_html_e( 'WooCommerce Support', 'wp-search-with-algolia' ); ?></h3>
+				<p class="algolia-pro-feature__lede"><?php esc_html_e( 'Catalog-grade search for WooCommerce stores. Surface the right product on the first keystroke.', 'wp-search-with-algolia' ); ?></p>
+				<ul class="algolia-pro-feature__list">
+					<li>
+						<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
+						<?php esc_html_e( 'Index SKUs, prices, short descriptions, and product dimensions or weight for richer result display.', 'wp-search-with-algolia' ); ?>
+					</li>
+					<li>
+						<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
+						<?php esc_html_e( 'Use total sales and product ratings as ranking signals so popular items rise to the top.', 'wp-search-with-algolia' ); ?>
+					</li>
+					<li>
+						<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
+						<?php esc_html_e( 'Toggle indexing of sold-out products, hidden products, and shop-only items per your store policy.', 'wp-search-with-algolia' ); ?>
+					</li>
+					<li>
+						<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
+						<?php esc_html_e( 'Restrict the index to WooCommerce products only when you need a pure product search.', 'wp-search-with-algolia' ); ?>
+					</li>
+					<li class="algolia-pro-feature__list-item--ai">
+						<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
+						<?php esc_html_e( 'Track add-to-cart events', 'wp-search-with-algolia' ); ?>
+						<span class="algolia-pro-feature__ai-tag" aria-label="<?php esc_attr_e( 'AI-powered feature', 'wp-search-with-algolia' ); ?>"><?php esc_html_e( 'AI', 'wp-search-with-algolia' ); ?></span>
+					</li>
+					<li class="algolia-pro-feature__list-item--ai">
+						<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
+						<?php esc_html_e( 'Track remove-from-cart events', 'wp-search-with-algolia' ); ?>
+						<span class="algolia-pro-feature__ai-tag" aria-label="<?php esc_attr_e( 'AI-powered feature', 'wp-search-with-algolia' ); ?>"><?php esc_html_e( 'AI', 'wp-search-with-algolia' ); ?></span>
+					</li>
+					<li class="algolia-pro-feature__list-item--ai">
+						<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
+						<?php esc_html_e( 'Track begin-checkout events', 'wp-search-with-algolia' ); ?>
+						<span class="algolia-pro-feature__ai-tag" aria-label="<?php esc_attr_e( 'AI-powered feature', 'wp-search-with-algolia' ); ?>"><?php esc_html_e( 'AI', 'wp-search-with-algolia' ); ?></span>
+					</li>
+				</ul>
+			</article>
+
+			<article class="algolia-pro-feature">
+				<div class="algolia-pro-feature__icon" aria-hidden="true">
+					<span class="dashicons dashicons-search"></span>
+				</div>
+				<h3 class="algolia-pro-feature__title"><?php esc_html_e( 'SEO Plugin Integrations', 'wp-search-with-algolia' ); ?></h3>
+				<p class="algolia-pro-feature__lede"><?php esc_html_e( 'Honor the editorial controls your team already uses. Indexing respects "noindex" decisions automatically.', 'wp-search-with-algolia' ); ?></p>
+				<ul class="algolia-pro-feature__list">
+					<li>
+						<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
+						<?php esc_html_e( 'Fine-tune indexing on individual posts, pages, or custom post types from the editor screen.', 'wp-search-with-algolia' ); ?>
+					</li>
+					<li>
+						<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
+						<?php esc_html_e( 'Drop-in support for Yoast SEO, All in One SEO, Rank Math, SEOPress, and The SEO Framework.', 'wp-search-with-algolia' ); ?>
+					</li>
+				</ul>
+			</article>
+		</div>
+
+		<div class="algolia-pro-upsell__footer">
+			<div>
+				<strong><?php esc_html_e( 'Ready to upgrade?', 'wp-search-with-algolia' ); ?></strong>
+				<span><?php esc_html_e( 'Add WP Search with Algolia Pro to your site today and give your visitors a faster, smarter search experience.', 'wp-search-with-algolia' ); ?></span>
+			</div>
+			<a class="algolia-pro-upsell__button-primary algolia-pro-upsell__button-primary--inverse" href="<?php echo esc_url( $pro_url ); ?>" target="_blank" rel="noopener noreferrer">
+				<?php esc_html_e( 'Get Pro now', 'wp-search-with-algolia' ); ?>
+				<span class="dashicons dashicons-arrow-right-alt" aria-hidden="true"></span>
+			</a>
+		</div>
+	</aside>
 </div>

--- a/includes/admin/partials/form-options.php
+++ b/includes/admin/partials/form-options.php
@@ -8,18 +8,27 @@
  * @package WebDevStudios\WPSWA
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$algolia_header_subtitle = __( 'Connect WordPress to Algolia, and control how search results behave across your site.', 'wp-search-with-algolia' );
+$algolia_header_actions  = '';
 ?>
 
-<div class="wrap">
-	<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+<div class="wrap algolia-settings-page">
+	<?php require dirname( __FILE__ ) . '/admin-header.php'; ?>
+
 	<?php if ( ! has_action( 'wpswa_pro_override_settings_output' ) ) : ?>
-		<form method="post" action="options.php">
-			<?php
-			settings_fields( $this->option_group );
-			do_settings_sections( $this->slug );
-			submit_button();
-			?>
-		</form>
+		<div class="algolia-settings-card">
+			<form method="post" action="options.php">
+				<?php
+				settings_fields( $this->option_group );
+				do_settings_sections( $this->slug );
+				submit_button();
+				?>
+			</form>
+		</div>
 	<?php else : ?>
 		<?php
 		/**
@@ -29,6 +38,7 @@
 		 *
 		 * @since 2.5.2
 		 */
-		do_action( 'wpswa_pro_override_settings_output' ); ?>
+		do_action( 'wpswa_pro_override_settings_output' );
+		?>
 	<?php endif; ?>
 </div>

--- a/includes/admin/partials/form-override-search-option.php
+++ b/includes/admin/partials/form-override-search-option.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<?php esc_html_e( 'Do not use Algolia for search', 'wp-search-with-algolia' ); ?>
 		</label>
 		<div class="radio-info">
-			<?php esc_html_e( 'Keep the standard WordPress search. Algolia is not involved in answering queries. Pick this if you want to disable Algolia search temporarily, or are still configuring autocomplete and not ready to flip the search page.', 'wp-search-with-algolia' ); ?>
+			<?php esc_html_e( 'Keep the standard WordPress search. Algolia is not involved in answering queries. Pick this if you want to disable Algolia search temporarily, or are still configuring search settingsg and not ready to flip the search page.', 'wp-search-with-algolia' ); ?>
 		</div>
 	</div>
 

--- a/includes/admin/partials/form-override-search-option.php
+++ b/includes/admin/partials/form-override-search-option.php
@@ -8,64 +8,58 @@
  * @package WebDevStudios\WPSWA
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 ?>
 
 <div class="input-radio">
-	<label>
-		<input type="radio" value="native"
-			name="algolia_override_native_search" <?php checked( $value, 'native' ); ?>>
-		<?php esc_html_e( 'Do not use Algolia', 'wp-search-with-algolia' ); ?>
-	</label>
-	<div class="radio-info">
-		<?php
-		echo wp_kses(
-			__(
-				'Do not use Algolia for any search. This option disables the search integration completely.',
-				'wp-search-with-algolia'
-			),
-			[
-				'br' => [],
-			]
-		);
-		?>
+
+	<div class="algolia-radio-option">
+		<label>
+			<input type="radio" value="native" name="algolia_override_native_search" <?php checked( $value, 'native' ); ?>>
+			<?php esc_html_e( 'Do not use Algolia for search', 'wp-search-with-algolia' ); ?>
+		</label>
+		<div class="radio-info">
+			<?php esc_html_e( 'Keep the standard WordPress search. Algolia is not involved in answering queries. Pick this if you want to disable Algolia search temporarily, or are still configuring autocomplete and not ready to flip the search page.', 'wp-search-with-algolia' ); ?>
+		</div>
 	</div>
 
-	<label>
-		<input type="radio" value="backend"
-			name="algolia_override_native_search" <?php checked( $value, 'backend' ); ?>>
-		<?php esc_html_e( 'Use Algolia with the native WordPress search template', 'wp-search-with-algolia' ); ?>
-	</label>
-	<div class="radio-info">
-		<?php
-		echo wp_kses(
-			__(
-				'Search results will be powered by Algolia and will use the standard WordPress search template for displaying the results.<br/>This option has the advantage to play nicely with any theme but does not support filtering and displaying InstantSearch results.',
-				'wp-search-with-algolia'
-			),
-			[
-				'br' => [],
-				'b'  => [],
-			]
-		);
-		?>
+	<div class="algolia-radio-option">
+		<label>
+			<input type="radio" value="backend" name="algolia_override_native_search" <?php checked( $value, 'backend' ); ?>>
+			<?php esc_html_e( 'Use Algolia, keep your theme&rsquo;s search template', 'wp-search-with-algolia' ); ?>
+		</label>
+		<div class="radio-info">
+			<?php
+			echo wp_kses(
+				__( 'Algolia answers the search query, but results render through your theme&rsquo;s existing <code>search.php</code> (or block search template). The safest choice for compatibility (works with virtually any theme), but <strong>does not</strong> include faceted filters, instant updates, or other InstantSearch UI features.', 'wp-search-with-algolia' ),
+				array(
+					'code'   => array(),
+					'strong' => array(),
+				)
+			);
+			?>
+		</div>
 	</div>
 
-	<label>
-		<input type="radio" value="instantsearch"
-			name="algolia_override_native_search" <?php checked( $value, 'instantsearch' ); ?>>
-		<?php esc_html_e( 'Use Algolia with Instantsearch.js', 'wp-search-with-algolia' ); ?>
-	</label>
-	<div class="radio-info">
-		<?php
-		echo wp_kses(
-			__(
-				'This will replace the WordPress search page with an InstantSearch experience powered by Algolia.<br/>By default you will be able to filter by post type, categories, tags and authors.',
-				'wp-search-with-algolia'
-			),
-			[
-				'br' => [],
-			]
-		);
-		?>
+	<div class="algolia-radio-option algolia-radio-option--recommended">
+		<label>
+			<input type="radio" value="instantsearch" name="algolia_override_native_search" <?php checked( $value, 'instantsearch' ); ?>>
+			<?php esc_html_e( 'Use Algolia with InstantSearch.js', 'wp-search-with-algolia' ); ?>
+			<span class="algolia-radio-badge"><?php esc_html_e( 'Recommended', 'wp-search-with-algolia' ); ?></span>
+		</label>
+		<div class="radio-info">
+			<?php
+			echo wp_kses(
+				__( 'Replaces the WordPress search page with a full Algolia InstantSearch UI: instant results as you type, typo tolerance, and built-in filters for post type, category, tag, and author. Customize by copying <code>templates/instantsearch.php</code> (or <code>instantsearch-modern.php</code>) into <code>your-theme/algolia/</code>. <strong>Block themes:</strong> see "Learn more" below for the extra step required.', 'wp-search-with-algolia' ),
+				array(
+					'code'   => array(),
+					'strong' => array(),
+				)
+			);
+			?>
+		</div>
 	</div>
+
 </div>

--- a/includes/admin/partials/form-override-search-option.php
+++ b/includes/admin/partials/form-override-search-option.php
@@ -52,7 +52,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<div class="radio-info">
 			<?php
 			echo wp_kses(
-				__( 'Replaces the WordPress search page with a full Algolia InstantSearch UI: instant results as you type, typo tolerance, and built-in filters for post type, category, tag, and author. Customize by copying <code>templates/instantsearch.php</code> (or <code>instantsearch-modern.php</code>) into <code>your-theme/algolia/</code>. <strong>Block themes:</strong> see "Learn more" below for the extra step required.', 'wp-search-with-algolia' ),
+				__( 'Replaces the WordPress search page with a full Algolia InstantSearch UI: instant results as you type, typo tolerance, and built-in filters for post type, category, tag, and author. Customize by copying <code>templates/instantsearch-modern.php</code> (or <code>instantsearch.php</code>) into <code>your-theme/algolia/</code>. <strong>Block themes:</strong> see "Learn more" below for the extra step required.', 'wp-search-with-algolia' ),
 				array(
 					'code'   => array(),
 					'strong' => array(),

--- a/includes/admin/partials/form-override-search-version-option.php
+++ b/includes/admin/partials/form-override-search-version-option.php
@@ -8,45 +8,39 @@
  * @package WebDevStudios\WPSWA
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 ?>
 
 <div class="input-radio">
-	<label>
-		<input type="radio" value="legacy"
-			name="algolia_instantsearch_template_version" <?php checked( $value, 'legacy' ); ?>>
-		<?php esc_html_e( 'Legacy (instantsearch.php)', 'wp-search-with-algolia' ); ?>
-	</label>
-	<div class="radio-info">
-		<?php
-		echo wp_kses(
-			__(
-				'Utilizes WP Utils library.',
-				'wp-search-with-algolia'
-			),
-			[
-				'br' => [],
-			]
-		);
-		?>
+
+	<div class="algolia-radio-option">
+		<label>
+			<input type="radio" value="legacy" name="algolia_instantsearch_template_version" <?php checked( $value, 'legacy' ); ?>>
+			<?php esc_html_e( 'Legacy', 'wp-search-with-algolia' ); ?>
+			<span class="algolia-radio-filename"><code>instantsearch.php</code></span>
+		</label>
+		<div class="radio-info">
+			<?php esc_html_e( 'Uses the older WP Utils JavaScript helpers. Stick with Legacy on existing sites that already have customizations targeting this template, or if you depend on the WP Utils helper functions.', 'wp-search-with-algolia' ); ?>
+		</div>
 	</div>
 
-	<label>
-		<input type="radio" value="modern"
-			name="algolia_instantsearch_template_version" <?php checked( $value, 'modern' ); ?>>
-		<?php esc_html_e( 'Modern (instantsearch-modern.php)', 'wp-search-with-algolia' ); ?>
-	</label>
-	<div class="radio-info">
-		<?php
-		echo wp_kses(
-			__(
-				'Uses Javascript template string literals and is more in line with Algolia documentation.',
-				'wp-search-with-algolia'
-			),
-			[
-				'br' => [],
-			]
-		);
-		?>
+	<div class="algolia-radio-option algolia-radio-option--recommended">
+		<label>
+			<input type="radio" value="modern" name="algolia_instantsearch_template_version" <?php checked( $value, 'modern' ); ?>>
+			<?php esc_html_e( 'Modern', 'wp-search-with-algolia' ); ?>
+			<span class="algolia-radio-filename"><code>instantsearch-modern.php</code></span>
+			<span class="algolia-radio-badge"><?php esc_html_e( 'Recommended', 'wp-search-with-algolia' ); ?></span>
+		</label>
+		<div class="radio-info">
+			<?php esc_html_e( 'Uses native JavaScript template literals and follows the patterns shown in current Algolia documentation. Best choice for new installs and any site without legacy template customizations.', 'wp-search-with-algolia' ); ?>
+		</div>
 	</div>
-	<p><strong><?php esc_html_e( 'Leave on current setting if you have InstantSearch customized via files in your active theme.', 'wp-search-with-algolia' ); ?></strong></p>
+
+	<p class="algolia-radio-footnote">
+		<span class="dashicons dashicons-info-outline" aria-hidden="true"></span>
+		<?php esc_html_e( 'If you have customized the InstantSearch template in your active theme (under an "algolia" folder), keep this setting on the version your custom file is based on.', 'wp-search-with-algolia' ); ?>
+	</p>
+
 </div>

--- a/includes/admin/partials/page-autocomplete-config.php
+++ b/includes/admin/partials/page-autocomplete-config.php
@@ -48,9 +48,7 @@ $prefix = $this->settings->get_index_name_prefix();
 								<span class="screen-reader-text"><?php esc_html_e( 'Enable this index in the autocomplete dropdown', 'wp-search-with-algolia' ); ?></span>
 							</label>
 							<h3 class="algolia-autocomplete-row__title"><?php echo esc_html( $index['admin_name'] ); ?></h3>
-						</div>
 
-						<div class="algolia-autocomplete-row__meta">
 							<span class="algolia-autocomplete-row__index-name">
 								<span class="screen-reader-text"><?php esc_html_e( 'Index name:', 'wp-search-with-algolia' ); ?></span>
 								<code><?php echo esc_html( $prefix . $index['index_id'] ); ?></code>
@@ -59,7 +57,7 @@ $prefix = $this->settings->get_index_name_prefix();
 								<span class="algolia-autocomplete-row__debounce">
 									<?php
 									printf(
-										/* translators: %s: custom debounce timing in milliseconds. */
+									/* translators: %s: custom debounce timing in milliseconds. */
 										esc_html__( 'Custom debounce: %s ms', 'wp-search-with-algolia' ),
 										esc_html( (string) $index['debounce'] )
 									);

--- a/includes/admin/partials/page-autocomplete-config.php
+++ b/includes/admin/partials/page-autocomplete-config.php
@@ -8,89 +8,109 @@
  * @package WebDevStudios\WPSWA
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$prefix = $this->settings->get_index_name_prefix();
 ?>
 
-<p class="description" id="home-description">
-	<?php esc_html_e( 'Configure the indices you want to display in the autocomplete search dropdown menu.', 'wp-search-with-algolia' ); ?>
-	<br />
-	<?php esc_html_e( 'Use the `Max. Suggestions` column to configure the number of results displayed by section.', 'wp-search-with-algolia' ); ?>
-	<br />
-	<?php esc_html_e( 'Use drag and drop to control the order of the sections in the autocomplete search dropdown menu.', 'wp-search-with-algolia' ); ?>
-</p>
-<table class="widefat table-autocomplete striped">
-	<thead>
-		<tr>
-			<th style="width: 20px;"></th>
-			<th style="width: 75px;"><?php esc_html_e( 'Enable', 'wp-search-with-algolia' ); ?></th>
-			<th><?php esc_html_e( 'Index', 'wp-search-with-algolia' ); ?></th>
-			<th><?php esc_html_e( 'Label', 'wp-search-with-algolia' ); ?></th>
-			<th style="width: 75px;"><?php esc_html_e( 'Max. Suggestions', 'wp-search-with-algolia' ); ?></th>
-			<th><?php esc_html_e( 'Actions', 'wp-search-with-algolia' ); ?></th>
-		</tr>
-	</thead>
-	<tbody>
-		<?php
-		$prefix = $this->settings->get_index_name_prefix(); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
-		foreach ( $indices as $index ) : // phpcs:ignore -- This is an admin partial.  ?>
-		<tr>
-			<td>
-				<span class="dashicons dashicons-move"></span>
-				<input type="hidden" class="position-input" name="algolia_autocomplete_config[<?php echo esc_attr( $index['index_id'] ); ?>][position]"  value="<?php echo (int) $index['position']; ?>" />
-			</td>
-			<td>
-				<input type="checkbox" name="algolia_autocomplete_config[<?php echo esc_attr( $index['index_id'] ); ?>][enabled]" <?php echo $index['enabled'] ? 'checked="checked"' : ''; ?>/>
-			</td>
-			<td>
-				<?php echo esc_html( $index['admin_name'] ); ?><br>
-				<small>
-					<?php
-					printf(
-						// translators: placeholder is the name of an Algolia search index.
-						esc_html__( 'Index name: %s', 'wp-search-with-algolia' ),
-						esc_html( $index['index_id'] )
-					);
-					?>
-				</small><br/>
-				<small>
-					<?php
-					printf(
-					// translators: placeholder is the name of an Algolia search index.
-						esc_html__( 'Prefixed: %1$s%2$s', 'wp-search-with-algolia' ),
-						esc_html( $prefix ),
-						esc_html( $index['index_id'] )
-					);
-					?>
-				</small>
-				<?php if ( ! empty( $index['debounce'] ) && $index['debounce'] > 0 ) : ?>
-					<br /><small>
-						<?php
-						printf(
-							// translators: placeholder is the custom debounce value.
-							esc_html__( 'Custom debounce timing: %s ms', 'wp-search-with-algolia' ),
-							esc_html( $index['debounce'] )
-						);
-						?>
-					</small>
-				<?php endif; ?>
-			</td>
-			<td>
-				<input type="text" name="algolia_autocomplete_config[<?php echo esc_attr( $index['index_id'] ); ?>][label]"  value="<?php echo esc_attr( $index['label'] ); ?>" />
-			</td>
-			<td>
-				<input type="number" class="small-text" name="algolia_autocomplete_config[<?php echo esc_attr( $index['index_id'] ); ?>][max_suggestions]"  value="<?php echo (int) $index['max_suggestions']; ?>" />
-			</td>
-			<td>
-				<button type="button" class="algolia-reindex-button button button-primary" data-index="<?php echo esc_attr( $index['index_id'] ); ?>"><?php esc_html_e( 'Re-index', 'wp-search-with-algolia' ); ?></button>
-				<button type="button" class="algolia-push-settings-button button" data-index="<?php echo esc_attr( $index['index_id'] ); ?>"><?php esc_html_e( 'Push Settings', 'wp-search-with-algolia' ); ?></button>
-			</td>
-		</tr>
-		<?php endforeach; ?>
-	</tbody>
-</table>
-<p class="description" id="home-description">
-	<?php esc_html_e( 'Configure the indices you want to display in the autocomplete search dropdown menu.', 'wp-search-with-algolia' ); ?>
-	<br />
-	<?php esc_html_e( 'Use the `Max. Suggestions` column to configure the number of results displayed by section.', 'wp-search-with-algolia' ); ?>
-	<br />
-	<?php esc_html_e( 'Use drag and drop to control the order of the sections in the autocomplete search dropdown menu.', 'wp-search-with-algolia' ); ?>
-</p>
+<?php if ( empty( $indices ) ) : ?>
+	<div class="algolia-autocomplete-config algolia-autocomplete-config--empty">
+		<p>
+			<span class="dashicons dashicons-info-outline" aria-hidden="true"></span>
+			<?php esc_html_e( 'No indices are available yet. Once you have at least one index configured on the Indexing page, it will appear here as a card you can drag, toggle, and tune.', 'wp-search-with-algolia' ); ?>
+		</p>
+	</div>
+<?php else : ?>
+	<div class="algolia-autocomplete-config">
+		<div class="algolia-autocomplete-list" role="list">
+			<?php foreach ( $indices as $index ) : ?>
+				<div class="algolia-autocomplete-row" role="listitem" data-index-id="<?php echo esc_attr( $index['index_id'] ); ?>">
+					<div class="algolia-autocomplete-row__handle" aria-label="<?php esc_attr_e( 'Drag to reorder', 'wp-search-with-algolia' ); ?>">
+						<span class="dashicons dashicons-move" aria-hidden="true"></span>
+						<input
+							type="hidden"
+							class="position-input"
+							name="algolia_autocomplete_config[<?php echo esc_attr( $index['index_id'] ); ?>][position]"
+							value="<?php echo (int) $index['position']; ?>"
+						/>
+					</div>
+
+					<div class="algolia-autocomplete-row__main">
+						<div class="algolia-autocomplete-row__header">
+							<label class="algolia-autocomplete-row__toggle">
+								<input
+									type="checkbox"
+									name="algolia_autocomplete_config[<?php echo esc_attr( $index['index_id'] ); ?>][enabled]"
+									<?php checked( ! empty( $index['enabled'] ) ); ?>
+								/>
+								<span class="screen-reader-text"><?php esc_html_e( 'Enable this index in the autocomplete dropdown', 'wp-search-with-algolia' ); ?></span>
+							</label>
+							<h3 class="algolia-autocomplete-row__title"><?php echo esc_html( $index['admin_name'] ); ?></h3>
+						</div>
+
+						<div class="algolia-autocomplete-row__meta">
+							<span class="algolia-autocomplete-row__index-name">
+								<span class="screen-reader-text"><?php esc_html_e( 'Index name:', 'wp-search-with-algolia' ); ?></span>
+								<code><?php echo esc_html( $prefix . $index['index_id'] ); ?></code>
+							</span>
+							<?php if ( ! empty( $index['debounce'] ) && $index['debounce'] > 0 ) : ?>
+								<span class="algolia-autocomplete-row__debounce">
+									<?php
+									printf(
+										/* translators: %s: custom debounce timing in milliseconds. */
+										esc_html__( 'Custom debounce: %s ms', 'wp-search-with-algolia' ),
+										esc_html( (string) $index['debounce'] )
+									);
+									?>
+								</span>
+							<?php endif; ?>
+						</div>
+
+						<div class="algolia-autocomplete-row__fields">
+							<label class="algolia-autocomplete-row__field">
+								<span class="algolia-autocomplete-row__field-label"><?php esc_html_e( 'Section label', 'wp-search-with-algolia' ); ?></span>
+								<input
+									type="text"
+									name="algolia_autocomplete_config[<?php echo esc_attr( $index['index_id'] ); ?>][label]"
+									value="<?php echo esc_attr( $index['label'] ); ?>"
+									placeholder="<?php echo esc_attr( $index['admin_name'] ); ?>"
+								/>
+							</label>
+							<label class="algolia-autocomplete-row__field algolia-autocomplete-row__field--narrow">
+								<span class="algolia-autocomplete-row__field-label"><?php esc_html_e( 'Max. suggestions', 'wp-search-with-algolia' ); ?></span>
+								<input
+									type="number"
+									class="small-text"
+									min="1"
+									name="algolia_autocomplete_config[<?php echo esc_attr( $index['index_id'] ); ?>][max_suggestions]"
+									value="<?php echo (int) $index['max_suggestions']; ?>"
+								/>
+							</label>
+						</div>
+					</div>
+
+					<div class="algolia-autocomplete-row__actions">
+						<button
+							type="button"
+							class="algolia-reindex-button button button-primary"
+							data-index="<?php echo esc_attr( $index['index_id'] ); ?>"
+						>
+							<span class="dashicons dashicons-update" aria-hidden="true"></span>
+							<?php esc_html_e( 'Re-index', 'wp-search-with-algolia' ); ?>
+						</button>
+						<button
+							type="button"
+							class="algolia-push-settings-button button"
+							data-index="<?php echo esc_attr( $index['index_id'] ); ?>"
+						>
+							<span class="dashicons dashicons-cloud-upload" aria-hidden="true"></span>
+							<?php esc_html_e( 'Push settings', 'wp-search-with-algolia' ); ?>
+						</button>
+					</div>
+				</div>
+			<?php endforeach; ?>
+		</div>
+	</div>
+<?php endif; ?>

--- a/includes/admin/partials/page-autocomplete.php
+++ b/includes/admin/partials/page-autocomplete.php
@@ -8,15 +8,24 @@
  * @package WebDevStudios\WPSWA
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$algolia_header_subtitle = __( 'Configure the autocomplete dropdown that appears as visitors type in your site search.', 'wp-search-with-algolia' );
+$algolia_header_actions  = '';
 ?>
 
-<div class="wrap">
-	<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
-	<form method="post" action="options.php">
-		<?php
-		settings_fields( $this->option_group );
-		do_settings_sections( $this->slug );
-		submit_button();
-		?>
-	</form>
+<div class="wrap algolia-settings-page">
+	<?php require dirname( __FILE__ ) . '/admin-header.php'; ?>
+
+	<div class="algolia-settings-card">
+		<form method="post" action="options.php">
+			<?php
+			settings_fields( $this->option_group );
+			do_settings_sections( $this->slug );
+			submit_button();
+			?>
+		</form>
+	</div>
 </div>

--- a/includes/admin/partials/page-search.php
+++ b/includes/admin/partials/page-search.php
@@ -8,23 +8,34 @@
  * @package WebDevStudios\WPSWA
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$algolia_header_subtitle = __( 'Choose how WordPress search uses Algolia, and re-index or push settings to keep results fresh.', 'wp-search-with-algolia' );
+
+ob_start();
+?>
+<button type="button" class="algolia-reindex-button button button-primary" data-index="searchable_posts">
+	<?php esc_html_e( 'Re-index All Content', 'wp-search-with-algolia' ); ?>
+</button>
+<button type="button" class="algolia-push-settings-button button" data-index="searchable_posts">
+	<?php esc_html_e( 'Push Settings', 'wp-search-with-algolia' ); ?>
+</button>
+<?php
+$algolia_header_actions = ob_get_clean();
 ?>
 
-<div class="wrap">
-	<h1>
-		<?php echo esc_html( get_admin_page_title() ); ?>
-		<button type="button" class="algolia-reindex-button button button-primary" data-index="searchable_posts">
-			<?php esc_html_e( 'Re-index All Content', 'wp-search-with-algolia' ); ?>
-		</button>
-		<button type="button" class="algolia-push-settings-button button" data-index="searchable_posts">
-			<?php esc_html_e( 'Push Settings', 'wp-search-with-algolia' ); ?>
-		</button>
-	</h1>
-	<form method="post" action="options.php">
-		<?php
-		settings_fields( $this->option_group );
-		do_settings_sections( $this->slug );
-		submit_button();
-		?>
-	</form>
+<div class="wrap algolia-settings-page">
+	<?php require dirname( __FILE__ ) . '/admin-header.php'; ?>
+
+	<div class="algolia-settings-card">
+		<form method="post" action="options.php">
+			<?php
+			settings_fields( $this->option_group );
+			do_settings_sections( $this->slug );
+			submit_button();
+			?>
+		</form>
+	</div>
 </div>


### PR DESCRIPTION
Refreshes the Algolia admin pages with a unified, on-brand interface and substantially clearer guidance for site owners.

The plugin's admin pages were plain-text forms with one-sentence help and no real visual identity. This update will help new and existing users understand the configuration options and ways the plugin can be integrated in to WordPress.

Highlights                                             

  - Consistent branded layout across Settings, Search, Autocomplete, and Premium Support.
  - Expanded inline help on every field, with collapsible "Learn more" disclosures and explicit notices when credentials are locked via wp-config.php.
  - Autocomplete config rebuilt from a cramped table into a clear, drag-and-drop card list.
  - New Pro CTA featuring a hero header, a dedicated Advanced Algolia AI Support panel, and equal-weight feature cards for Multisite, WooCommerce, and SEO integrations.
  - Premium Support now positions WebDevStudios as a long-term WordPress partner alongside the Pro upsell.