### PR TITLE
make sure we have an index object before checking if enabled

### DIFF
--- a/includes/utilities/class-algolia-health-panel.php
+++ b/includes/utilities/class-algolia-health-panel.php
@@ -62,7 +62,7 @@ class Algolia_Health_Panel {
 				],
 				[
 					'label' => 'Searchable Posts Index Enabled',
-					'value' => $this->plugin->get_index( 'searchable_posts' )->is_enabled() ? 'true' : 'false',
+					'value' => $this->plugin->get_index( 'searchable_posts' ) && $this->plugin->get_index( 'searchable_posts' )->is_enabled() ? 'true' : 'false',
 				],
 				[
 					'label' => 'Autocomplete Enabled',


### PR DESCRIPTION
This PR checks if we have an index first, before checking if enabled.

This situation would arise if visiting the Health panel, before saving application/api data to our Algolia settings.