### PR TITLE
Feature/wdsp 2481 search filters

### DIFF
--- a/includes/class-algolia-search.php
+++ b/includes/class-algolia-search.php
@@ -179,8 +179,8 @@ class Algolia_Search {
 			return;
 		}
 
-		add_filter( 'found_posts', array( $this, 'found_posts' ), 10, 2 );
-		add_filter( 'posts_search', array( $this, 'posts_search' ), 10, 2 );
+		add_filter( 'found_posts', [ $this, 'found_posts' ], 10, 2 );
+		add_filter( 'posts_search', [ $this, 'posts_search' ], 10, 2 );
 
 		// Store the current page hits, so that we can use them for highlighting later on.
 		foreach ( $results['hits'] as $hit ) {
@@ -191,7 +191,7 @@ class Algolia_Search {
 		// This is useful for pagination.
 		$this->total_hits = $results['nbHits'];
 
-		$post_ids = array();
+		$post_ids = [];
 		foreach ( $results['hits'] as $result ) {
 			$post_ids[] = $result['post_id'];
 		}
@@ -200,7 +200,7 @@ class Algolia_Search {
 		// a non existing post ID.
 		// Otherwise, the query returns all the results.
 		if ( empty( $post_ids ) ) {
-			$post_ids = array( 0 );
+			$post_ids = [ 0 ];
 		}
 
 		$query->set( 'posts_per_page', $params['hitsPerPage'] );

--- a/includes/class-algolia-search.php
+++ b/includes/class-algolia-search.php
@@ -114,6 +114,16 @@ class Algolia_Search {
 		}
 
 		/**
+		 * Filters the search query used in the Algolia Index search.
+		 *
+		 * @since 2.13.0
+		 *
+		 * @param string   $value Searched query value.
+		 * @param WP_Query $query Search query object.
+		 */
+		$search_query = apply_filters( 'algolia_search_query', $query->query['s'], $query );
+
+		/**
 		 * Filters the array of parameters used in the Algolia Index search.
 		 *
 		 * @author WebDevStudios <contact@webdevstudios.com>
@@ -162,7 +172,7 @@ class Algolia_Search {
 		$order    = apply_filters( 'algolia_search_order', 'desc' );
 
 		try {
-			$results = $this->index->search( $query->query['s'], $params, $order_by, $order );
+			$results = $this->index->search( $search_query, $params, $order_by, $order );
 		} catch ( AlgoliaException $exception ) {
 			error_log( $exception->getMessage() ); // phpcs:ignore -- Legacy.
 


### PR DESCRIPTION
# Handles

https://github.com/WebDevStudios/wp-search-with-algolia/issues/465

1. Adds a filter in our `pre_get_posts` callback to allow for modifying the search query, before sending to Algolia.
2. Modernizes a handful of spots for array declaration, while we're here.