### PR TITLE
Minimum WP and Composer adjustments

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,7 +1,7 @@
 === WP Search with Algolia ===
 Contributors: WebDevStudios, williamsba1, tw2113, mrasharirfan, scottbasgaard, gregrickaby, richaber, daveromsey
 Tags: algolia, autocomplete, instantsearch, relevance search, ai search
-Requires at least: 6.7.2
+Requires at least: 6.2.9
 Tested up to: 7.0
 Requires PHP: 7.4
 Stable tag: 2.13.0

--- a/algolia.php
+++ b/algolia.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://github.com/WebDevStudios/wp-search-with-algolia
  * Description:       Integrate the powerful Algolia search service with WordPress
  * Version:           2.13.0
- * Requires at least: 6.7.2
+ * Requires at least: 6.2.9
  * Requires PHP:      7.4
  * Author:            WebDevStudios
  * Author URI:        https://webdevstudios.com
@@ -32,7 +32,7 @@ define( 'ALGOLIA_VERSION', '2.13.0' );
 define( 'ALGOLIA_MIN_PHP_VERSION', '7.4' );
 
 // The minimum required WordPress version.
-define( 'ALGOLIA_MIN_WP_VERSION', '6.7.2' );
+define( 'ALGOLIA_MIN_WP_VERSION', '6.2.9' );
 
 define( 'ALGOLIA_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "prefer-stable": true,
   "require": {
     "php": ">=7.4",
-    "composer/installers": "~1.0"
+    "composer/installers": "~1.0|~2.0"
   },
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",


### PR DESCRIPTION
This PR brings in some compatibility changes for ClassicPress which is still on version 6.2.9 for their matching needs. See https://github.com/WebDevStudios/wp-search-with-algolia/issues/562

We originally bumped to the almost latest version at the time, for the sake of it, but we are still actually completely compatible with 6.2.9 at least.

It also adjusts composer/installers to allow for 2.0. See https://github.com/WebDevStudios/wp-search-with-algolia/issues/563

