### PR TITLE
Add Algolia_Plugin::sync_item() to support programmatic sync of a single item

### DIFF
--- a/includes/class-algolia-plugin.php
+++ b/includes/class-algolia-plugin.php
@@ -442,7 +442,7 @@ class Algolia_Plugin {
 	}
 
 	/**
-	 * Sync a single item to a given index by ID.
+	 * Sync a single WP_Post item to a given index by ID.
 	 *
 	 * Convenience wrapper so external code (themes, plugins, CLI commands) can
 	 * sync a single item without needing to construct an Algolia_Index or
@@ -456,7 +456,7 @@ class Algolia_Plugin {
 	 *
 	 * @return void
 	 */
-	public function sync_item( $item, $index_id = 'searchable_posts' ) {
+	public function sync_post_item( $item, $index_id = 'searchable_posts' ) {
 		$index = $this->get_index( $index_id );
 
 		if ( ! $index ) {

--- a/includes/class-algolia-plugin.php
+++ b/includes/class-algolia-plugin.php
@@ -8,6 +8,8 @@
  * @package WebDevStudios\WPSWA
  */
 
+use WebDevStudios\WPSWA\Algolia\AlgoliaSearch\Exceptions\AlgoliaException;
+
 /**
  * Class Algolia_Plugin
  *
@@ -437,6 +439,43 @@ class Algolia_Plugin {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Sync a single item to a given index by ID.
+	 *
+	 * Convenience wrapper so external code (themes, plugins, CLI commands) can
+	 * sync a single item without needing to construct an Algolia_Index or
+	 * Algolia_Changes_Watcher themselves.
+	 *
+	 * @author WebDevStudios <contact@webdevstudios.com>
+	 * @since  3.0.0
+	 *
+	 * @param int|WP_Post $item     The item to sync (e.g. a post ID or WP_Post object).
+	 * @param string      $index_id The ID of the index to sync into. Default 'searchable_posts'.
+	 *
+	 * @return void
+	 */
+	public function sync_item( $item, $index_id = 'searchable_posts' ) {
+		$index = $this->get_index( $index_id );
+
+		if ( ! $index ) {
+			return;
+		}
+
+		if ( is_numeric( $item ) ) {
+			$item = get_post( (int) $item );
+		}
+
+		if ( ! $item || ! $index->supports( $item ) ) {
+			return;
+		}
+
+		try {
+			$index->sync( $item );
+		} catch ( AlgoliaException $exception ) {
+			error_log( $exception->getMessage() ); // phpcs:ignore -- Legacy.
+		}
 	}
 
 	/**


### PR DESCRIPTION
Currently, syncing a single item outside the plugin's own watchers requires manually constructing an Algolia_Index, wiring up the client, name prefix, and enabled flag, then instantiating a change watcher just to call sync_item(). This exposes a public convenience method that reuses the plugin's already-configured indices via get_index().

Code required before this PR: 

```php
	// Get the parts of the Algolia plugin we need for indexing.
	$plugin            = Algolia_Plugin_Factory::create();
	$client            = $plugin->get_api()->get_client();
	$index_name_prefix = $plugin->get_settings()->get_index_name_prefix();

	// Add a searchable posts index.
	$searchable_post_types = get_post_types(
		array(
			'exclude_from_search' => false,
		),
		'names'
	);
	$searchable_post_types = (array) apply_filters( 'algolia_searchable_post_types', $searchable_post_types );
	$index                 = new Algolia_Searchable_Posts_Index( $searchable_post_types );
	$index->set_name_prefix( $index_name_prefix );
	$index->set_client( $client );
	$index->set_enabled( true );

	// The Post changes watcher is the only one that we'll need on save_post.
	$watcher = new Algolia_Post_Changes_Watcher( $index );

	// Sync the post ID.
	$watcher->sync_item( $post_id );

```

Code required after: 

```php
	Algolia_Plugin_Factory::create()->sync_item( $post_id );
```

PR in relation to #499 