### PR TITLE
Make sure the algolia plugin is blog context aware in a multisite

### DIFF
--- a/includes/class-algolia-plugin.php
+++ b/includes/class-algolia-plugin.php
@@ -180,7 +180,6 @@ class Algolia_Plugin {
 		$this->update_messages = new Algolia_Update_Messages();
 
 		add_action( 'init', array( $this, 'load' ), 20 );
-		add_action( 'switch_blog', array( $this, 'on_switch_blog' ), PHP_INT_MAX, 2 );
 	}
 
 	/**
@@ -190,6 +189,8 @@ class Algolia_Plugin {
 	 * @since  1.0.0
 	 */
 	public function load() {
+		add_action( 'switch_blog', array( $this, 'on_switch_blog' ), PHP_INT_MAX, 2 );
+
 		if ( $this->api->is_reachable() ) {
 			$this->load_indices();
 			$this->override_wordpress_search();

--- a/includes/class-algolia-plugin.php
+++ b/includes/class-algolia-plugin.php
@@ -58,6 +58,13 @@ class Algolia_Plugin {
 	private $indices;
 
 	/**
+	 * Array of indices keyed by blog ID.
+	 *
+	 * @var array
+	 */
+	private $indices_by_blog = array();
+
+	/**
 	 * Array of watchers.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
@@ -66,6 +73,13 @@ class Algolia_Plugin {
 	 * @var array
 	 */
 	private $changes_watchers;
+
+	/**
+	 * Array of watchers keyed by blog ID.
+	 *
+	 * @var array
+	 */
+	private $changes_watchers_by_blog = array();
 
 	/**
 	 * Instance of Algolia_Styles.
@@ -166,6 +180,7 @@ class Algolia_Plugin {
 		$this->update_messages = new Algolia_Update_Messages();
 
 		add_action( 'init', array( $this, 'load' ), 20 );
+		add_action( 'switch_blog', array( $this, 'on_switch_blog' ), PHP_INT_MAX, 2 );
 	}
 
 	/**
@@ -187,6 +202,26 @@ class Algolia_Plugin {
 			$this->admin  = new Algolia_Admin( $this );
 			$this->health = new Algolia_Health_Panel( $this );
 		}
+	}
+
+	/**
+	 * Ensure indices/watchers are initialized for the switched blog.
+	 *
+	 * @param int $new_blog_id      New blog ID.
+	 * @param int $previous_blog_id Previous blog ID.
+	 *
+	 * @return void
+	 */
+	public function on_switch_blog( $new_blog_id, $previous_blog_id ) {
+		if ( (int) $new_blog_id === (int) $previous_blog_id ) {
+			return;
+		}
+
+		if ( ! $this->api->is_reachable() ) {
+			return;
+		}
+
+		$this->load_indices( (int) $new_blog_id );
 	}
 
 	/**
@@ -284,7 +319,18 @@ class Algolia_Plugin {
 	 * @author WebDevStudios <contact@webdevstudios.com>
 	 * @since  1.0.0
 	 */
-	public function load_indices() {
+	public function load_indices( $blog_id = null ) {
+		$blog_id = null === $blog_id ? (int) get_current_blog_id() : (int) $blog_id;
+
+		if ( isset( $this->indices_by_blog[ $blog_id ], $this->changes_watchers_by_blog[ $blog_id ] ) ) {
+			$this->indices          = $this->indices_by_blog[ $blog_id ];
+			$this->changes_watchers = $this->changes_watchers_by_blog[ $blog_id ];
+			return;
+		}
+
+		$this->indices          = array();
+		$this->changes_watchers = array();
+
 		$synced_indices_ids = $this->settings->get_synced_indices_ids();
 
 		$client            = $this->get_api()->get_client();
@@ -355,11 +401,11 @@ class Algolia_Plugin {
 				$index->set_enabled( true );
 
 				if ( $index->contains_only( 'posts' ) ) {
-					$this->changes_watchers[] = new Algolia_Post_Changes_Watcher( $index );
+					$this->changes_watchers[] = new Algolia_Post_Changes_Watcher( $index, $blog_id );
 				} elseif ( $index->contains_only( 'terms' ) ) {
-					$this->changes_watchers[] = new Algolia_Term_Changes_Watcher( $index );
+					$this->changes_watchers[] = new Algolia_Term_Changes_Watcher( $index, $blog_id );
 				} elseif ( $index->contains_only( 'users' ) ) {
-					$this->changes_watchers[] = new Algolia_User_Changes_Watcher( $index );
+					$this->changes_watchers[] = new Algolia_User_Changes_Watcher( $index, $blog_id );
 				}
 			}
 		}
@@ -378,6 +424,9 @@ class Algolia_Plugin {
 		foreach ( $this->changes_watchers as $watcher ) {
 			$watcher->watch();
 		}
+
+		$this->indices_by_blog[ $blog_id ]          = $this->indices;
+		$this->changes_watchers_by_blog[ $blog_id ] = $this->changes_watchers;
 	}
 
 	/**

--- a/includes/watchers/class-algolia-post-changes-watcher.php
+++ b/includes/watchers/class-algolia-post-changes-watcher.php
@@ -28,6 +28,13 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 	private $index;
 
 	/**
+	 * Blog ID this watcher is bound to.
+	 *
+	 * @var int
+	 */
+	private $blog_id;
+
+	/**
 	 * Deleted posts array.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
@@ -95,8 +102,18 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 	 *
 	 * @param Algolia_Index $index Algolia_Index instance.
 	 */
-	public function __construct( Algolia_Index $index ) {
-		$this->index = $index;
+	public function __construct( Algolia_Index $index, $blog_id = null ) {
+		$this->index   = $index;
+		$this->blog_id = null === $blog_id ? (int) get_current_blog_id() : (int) $blog_id;
+	}
+
+	/**
+	 * Check whether this watcher should handle current blog events.
+	 *
+	 * @return bool
+	 */
+	private function is_current_blog_context() {
+		return (int) get_current_blog_id() === $this->blog_id;
 	}
 
 	/**
@@ -141,6 +158,9 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 	 * @return void
 	 */
 	public function sync_item( $post_id ) {
+		if ( ! $this->is_current_blog_context() ) {
+			return;
+		}
 
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;
@@ -182,6 +202,10 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 	 * @return void
 	 */
 	public function check_slug_update( $post_id, $post_data ) {
+		if ( ! $this->is_current_blog_context() ) {
+			return;
+		}
+
 		$post = get_post( (int) $post_id );
 		if ( isset( $post_data['post_name'] ) && $post_data['post_name'] !== $post->post_name ) {
 
@@ -213,6 +237,9 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 	 * @return void
 	 */
 	public function delete_item( $post_id ) {
+		if ( ! $this->is_current_blog_context() ) {
+			return;
+		}
 
 		$post = get_post( (int) $post_id );
 		if ( ! $post || ! $this->index->supports( $post ) ) {
@@ -241,6 +268,10 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 	 * @return void
 	 */
 	public function on_meta_change( $meta_id, $object_id, $meta_key, $meta_value ) {
+		if ( ! $this->is_current_blog_context() ) {
+			return;
+		}
+
 		$keys = array( '_thumbnail_id' );
 
 		/**
@@ -271,6 +302,9 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 	 * @return void
 	 */
 	public function track_updated_posts( $post_id ) {
+		if ( ! $this->is_current_blog_context() ) {
+			return;
+		}
 
 		// If `save_post` has not been executed, it means "fast mode" of WP All Import is enabled.
 		if ( in_array( $post_id, $this->posts_updated, true ) ) {
@@ -290,6 +324,10 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 	 * @return void
 	 */
 	public function sync_item_for_pmxi( $import_id ) {
+		if ( ! $this->is_current_blog_context() ) {
+			return;
+		}
+
 		$current_page = (int) get_option( 'algolia_pmxi_page', 1 );
 
 		if ( null === self::$pmxi_is_fast_mode ) {

--- a/includes/watchers/class-algolia-term-changes-watcher.php
+++ b/includes/watchers/class-algolia-term-changes-watcher.php
@@ -27,6 +27,13 @@ class Algolia_Term_Changes_Watcher implements Algolia_Changes_Watcher {
 	private $index;
 
 	/**
+	 * Blog ID this watcher is bound to.
+	 *
+	 * @var int
+	 */
+	private $blog_id;
+
+	/**
 	 * Active Algolia Indices
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
@@ -43,8 +50,18 @@ class Algolia_Term_Changes_Watcher implements Algolia_Changes_Watcher {
 	 *
 	 * @param Algolia_Index $index Algolia_Index instance.
 	 */
-	public function __construct( Algolia_Index $index ) {
-		$this->index = $index;
+	public function __construct( Algolia_Index $index, $blog_id = null ) {
+		$this->index   = $index;
+		$this->blog_id = null === $blog_id ? (int) get_current_blog_id() : (int) $blog_id;
+	}
+
+	/**
+	 * Check whether this watcher should handle current blog events.
+	 *
+	 * @return bool
+	 */
+	private function is_current_blog_context() {
+		return (int) get_current_blog_id() === $this->blog_id;
 	}
 
 	/**
@@ -84,6 +101,10 @@ class Algolia_Term_Changes_Watcher implements Algolia_Changes_Watcher {
 	 * @return void
 	 */
 	public function sync_term_posts( $term_id, $tt_id, $taxonomy ) {
+		if ( ! $this->is_current_blog_context() ) {
+			return;
+		}
+
 		$term = get_term( (int) $term_id );
 		if ( ! $term || ! $this->index->supports( $term ) ) {
 			return;
@@ -199,6 +220,10 @@ class Algolia_Term_Changes_Watcher implements Algolia_Changes_Watcher {
 	 * @return void
 	 */
 	public function sync_item( $term_id ) {
+		if ( ! $this->is_current_blog_context() ) {
+			return;
+		}
+
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;
 		}
@@ -230,6 +255,10 @@ class Algolia_Term_Changes_Watcher implements Algolia_Changes_Watcher {
 	 * @param array  $old_tt_ids Old array of term taxonomy IDs.
 	 */
 	public function handle_changes( $object_id, $terms, $tt_ids, $taxonomy, $append, $old_tt_ids ) {
+		if ( ! $this->is_current_blog_context() ) {
+			return;
+		}
+
 		$terms_to_sync = array_unique( array_merge( $terms, $old_tt_ids ) );
 
 		foreach ( $terms_to_sync as $term_id ) {
@@ -252,6 +281,10 @@ class Algolia_Term_Changes_Watcher implements Algolia_Changes_Watcher {
 	 * @return void
 	 */
 	public function on_delete_term( $term, $tt_id, $taxonomy, $deleted_term ) {
+		if ( ! $this->is_current_blog_context() ) {
+			return;
+		}
+
 		if ( ! $this->index->supports( $deleted_term ) ) {
 			return;
 		}
@@ -276,6 +309,9 @@ class Algolia_Term_Changes_Watcher implements Algolia_Changes_Watcher {
 	 * @since  2.5.0
 	 */
 	public function on_meta_change( $meta_id, $object_id, $meta_key, $meta_value ) {
+		if ( ! $this->is_current_blog_context() ) {
+			return;
+		}
 
 		// We will not listen for any specific key by default.
 		$keys = [];
@@ -305,6 +341,10 @@ class Algolia_Term_Changes_Watcher implements Algolia_Changes_Watcher {
 	 * @since 2.11.3
 	 */
 	public function large_count_notice() {
+		if ( ! $this->is_current_blog_context() ) {
+			return;
+		}
+
 		global $current_screen;
 
 		if ( ! $current_screen || 'term' !== $current_screen->base ) {

--- a/includes/watchers/class-algolia-user-changes-watcher.php
+++ b/includes/watchers/class-algolia-user-changes-watcher.php
@@ -28,6 +28,13 @@ class Algolia_User_Changes_Watcher implements Algolia_Changes_Watcher {
 	private $index;
 
 	/**
+	 * Blog ID this watcher is bound to.
+	 *
+	 * @var int
+	 */
+	private $blog_id;
+
+	/**
 	 * Algolia_User_Changes_Watcher constructor.
 	 *
 	 * @author WebDevStudios <contact@webdevstudios.com>
@@ -35,8 +42,18 @@ class Algolia_User_Changes_Watcher implements Algolia_Changes_Watcher {
 	 *
 	 * @param Algolia_Index $index Algolia_Index instance.
 	 */
-	public function __construct( Algolia_Index $index ) {
-		$this->index = $index;
+	public function __construct( Algolia_Index $index, $blog_id = null ) {
+		$this->index   = $index;
+		$this->blog_id = null === $blog_id ? (int) get_current_blog_id() : (int) $blog_id;
+	}
+
+	/**
+	 * Check whether this watcher should handle current blog events.
+	 *
+	 * @return bool
+	 */
+	private function is_current_blog_context() {
+		return (int) get_current_blog_id() === $this->blog_id;
 	}
 
 	/**
@@ -79,6 +96,10 @@ class Algolia_User_Changes_Watcher implements Algolia_Changes_Watcher {
 	 * @return void
 	 */
 	public function sync_item( $user_id ) {
+		if ( ! $this->is_current_blog_context() ) {
+			return;
+		}
+
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;
 		}
@@ -107,6 +128,10 @@ class Algolia_User_Changes_Watcher implements Algolia_Changes_Watcher {
 	 * @return void
 	 */
 	public function delete_item( $user_id ) {
+		if ( ! $this->is_current_blog_context() ) {
+			return;
+		}
+
 		$user = get_user_by( 'id', $user_id );
 
 		if ( ! $user || ! $this->index->supports( $user ) ) {
@@ -130,6 +155,10 @@ class Algolia_User_Changes_Watcher implements Algolia_Changes_Watcher {
 	 * @param WP_Post $post    Post object.
 	 */
 	public function on_save_post( $post_id, WP_Post $post ) {
+		if ( ! $this->is_current_blog_context() ) {
+			return;
+		}
+
 		$this->sync_item( (int) $post->post_author );
 	}
 
@@ -144,6 +173,10 @@ class Algolia_User_Changes_Watcher implements Algolia_Changes_Watcher {
 	 * @return void
 	 */
 	public function on_delete_post( $post_id ) {
+		if ( ! $this->is_current_blog_context() ) {
+			return;
+		}
+
 		$post = get_post( (int) $post_id );
 
 		if ( ! $post ) {
@@ -178,6 +211,9 @@ class Algolia_User_Changes_Watcher implements Algolia_Changes_Watcher {
 	 * @since  2.5.0
 	 */
 	public function on_meta_change( $meta_id, $object_id, $meta_key, $meta_value ) {
+		if ( ! $this->is_current_blog_context() ) {
+			return;
+		}
 
 		// We will not listen for any specific key by default.
 		$keys = [];


### PR DESCRIPTION
This PR fixes incorrect Algolia index targeting in multisite environments when content is saved during a switched blog context. Many plugins like [MultilingualPress](https://multilingualpress.org/) and [Distributor](https://distributorplugin.com/) use switch_to_blog for their core functionality.

Fixes #565  

What changed:
- Added blog-aware initialization in class-algolia-plugin.php
- Added a switch_blog listener to initialize/select the correct watcher/index set per blog.
- Added per-blog caches for indices and watchers to avoid rebuilding on repeated switches.
- Bound watcher instances to a specific blog ID and added context guards so callbacks run only when current blog context matches.

Feel free to make any adjustments. Right now I've tested this both with the easy reproducible scenario in #565 and with a multisite that uses MultilingualPress and that works fine now. For now we will deploy this to our multisite as a patch and do some further testing.