### PR TITLE
Release2141

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.14.1
+* Fixed: Settings, Autocomplete, and Native Search admin notices no longer appear on unrelated wp-admin screens (e.g. WooCommerce Edit Order).
+
 ## 2.14.0
 * Added: `Algolia_Pro` class as the single source of truth for Pro feature data, pricing, requirements, and outbound links.
 * Added: Pro requirements check so you can confirm your site meets Pro's WordPress, PHP, and plugin version minimums before purchasing.

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Tags: algolia, search, autocomplete, instantsearch, ai search
 Requires at least: 6.2.9
 Tested up to: 7.1
 Requires PHP: 7.4
-Stable tag: 2.14.0
+Stable tag: 2.14.1
 License: GNU General Public License v2.0, MIT License
 
 Use Algolia AI Search & Discovery to power your website's search with AI-powered Autocomplete and InstantSearch for fast, accurate, relevant results.
@@ -147,6 +147,9 @@ All development is handled on [GitHub](https://github.com/WebDevStudios/wp-searc
 == Changelog ==
 
 Follow along with the changelog on [GitHub](https://github.com/WebDevStudios/wp-search-with-algolia/releases).
+
+= 2.14.1 =
+* Fixed: Settings, Autocomplete, and Native Search admin notices no longer appear on unrelated wp-admin screens (e.g. WooCommerce Edit Order).
 
 = 2.14.0 =
 * Added: `Algolia_Pro` class as the single source of truth for Pro feature data, pricing, requirements, and outbound links.

--- a/algolia.php
+++ b/algolia.php
@@ -3,7 +3,7 @@
  * Plugin Name:       WP Search with Algolia
  * Plugin URI:        https://github.com/WebDevStudios/wp-search-with-algolia
  * Description:       Integrate the powerful Algolia search service with WordPress
- * Version:           2.14.0
+ * Version:           2.14.1
  * Requires at least: 6.2.9
  * Requires PHP:      7.4
  * Author:            WebDevStudios
@@ -26,7 +26,7 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 // The Algolia Search plugin version.
-define( 'ALGOLIA_VERSION', '2.14.0' );
+define( 'ALGOLIA_VERSION', '2.14.1' );
 
 // The minmum required PHP version.
 define( 'ALGOLIA_MIN_PHP_VERSION', '7.4' );

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "webdevstudios/wp-search-with-algolia",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "Integrate the powerful Algolia search service with WordPress.",
   "authors": [
     {

--- a/includes/admin/class-algolia-admin-page-autocomplete.php
+++ b/includes/admin/class-algolia-admin-page-autocomplete.php
@@ -375,6 +375,11 @@ class Algolia_Admin_Page_Autocomplete {
 	 * @return void
 	 */
 	public function display_errors() {
+		$maybe_get_page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_SPECIAL_CHARS );
+		if ( empty( $maybe_get_page ) || $this->slug !== $maybe_get_page ) {
+			return;
+		}
+
 		settings_errors( $this->option_group );
 
 		if ( defined( 'ALGOLIA_HIDE_HELP_NOTICES' ) && ALGOLIA_HIDE_HELP_NOTICES ) {

--- a/includes/admin/class-algolia-admin-page-autocomplete.php
+++ b/includes/admin/class-algolia-admin-page-autocomplete.php
@@ -243,12 +243,10 @@ class Algolia_Admin_Page_Autocomplete {
 		$value   = $this->settings->get_autocomplete_template_version();
 		$indices = $this->autocomplete_config->get_form_data();
 		?>
-		<input type="radio" id="legacy" name="algolia_autocomplete_template_version" value="legacy"<?php checked( 'legacy', $value );
-		disabled( empty( $indices ), true ); ?> />
+		<input type="radio" id="legacy" name="algolia_autocomplete_template_version" value="legacy" <?php checked( 'legacy', $value ); ?> <?php disabled( empty( $indices ), true ); ?>/>
 		<label for="legacy"><?php esc_html_e( 'Legacy', 'wp-search-with-algolia' ); ?></label>
 
-		<input type="radio" id="modern" name="algolia_autocomplete_template_version" value="modern"<?php checked( 'modern', $value );
-		disabled( empty( $indices ), true ); ?> />
+		<input type="radio" id="modern" name="algolia_autocomplete_template_version" value="modern" <?php checked( 'modern', $value ); ?> <?php disabled( empty( $indices ), true ); ?>/>
 		<label for="modern"><?php esc_html_e( 'Modern', 'wp-search-with-algolia' ); ?></label>
 		<?php
 

--- a/includes/admin/class-algolia-admin-page-native-search.php
+++ b/includes/admin/class-algolia-admin-page-native-search.php
@@ -254,6 +254,11 @@ class Algolia_Admin_Page_Native_Search {
 	 * @return void
 	 */
 	public function display_errors() {
+		$maybe_get_page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_SPECIAL_CHARS );
+		if ( empty( $maybe_get_page ) || $this->slug !== $maybe_get_page ) {
+			return;
+		}
+
 		settings_errors( $this->option_group );
 
 		if ( defined( 'ALGOLIA_HIDE_HELP_NOTICES' ) && ALGOLIA_HIDE_HELP_NOTICES ) {
@@ -266,13 +271,11 @@ class Algolia_Admin_Page_Native_Search {
 			return;
 		}
 
-		$maybe_get_page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_SPECIAL_CHARS );
-
 		$searchable_posts_index = $this->plugin->get_index( 'searchable_posts' );
 		if ( empty( $searchable_posts_index ) ) {
 			return;
 		}
-		if ( false === $searchable_posts_index->is_enabled() && ( ! empty( $maybe_get_page ) ) && $maybe_get_page === $this->slug ) {
+		if ( false === $searchable_posts_index->is_enabled() ) {
 			// translators: placeholder contains the link to the indexing page.
 			$message = sprintf( __( 'Searchable posts index needs to be checked on the <a href="%s">Algolia: Indexing page</a> for the search results to be powered by Algolia.', 'wp-search-with-algolia' ), esc_url( admin_url( 'admin.php?page=algolia-indexing' ) ) );
 			echo '<div class="error notice">

--- a/includes/admin/class-algolia-admin-page-settings.php
+++ b/includes/admin/class-algolia-admin-page-settings.php
@@ -650,6 +650,11 @@ class Algolia_Admin_Page_Settings {
 	 * @since  1.0.0
 	 */
 	public function display_errors() {
+		$maybe_get_page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_SPECIAL_CHARS );
+		if ( empty( $maybe_get_page ) || $this->slug !== $maybe_get_page ) {
+			return;
+		}
+
 		settings_errors( $this->option_group );
 	}
 

--- a/includes/admin/partials/page-autocomplete-config.php
+++ b/includes/admin/partials/page-autocomplete-config.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals -- This is a template partial variable, not a true global.
 $prefix = $this->settings->get_index_name_prefix();
 ?>
 
@@ -25,6 +26,7 @@ $prefix = $this->settings->get_index_name_prefix();
 <?php else : ?>
 	<div class="algolia-autocomplete-config">
 		<div class="algolia-autocomplete-list" role="list">
+			<?php // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals -- This is a template partial loop variable, not a true global. ?>
 			<?php foreach ( $indices as $index ) : ?>
 				<div class="algolia-autocomplete-row" role="listitem" data-index-id="<?php echo esc_attr( $index['index_id'] ); ?>">
 					<div class="algolia-autocomplete-row__handle" aria-label="<?php esc_attr_e( 'Drag to reorder', 'wp-search-with-algolia' ); ?>">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-search-with-algolia",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "Integrate the powerful Algolia search service with WordPress.",
   "author": "WebDevStudios",
   "license": "GPL-3.0",


### PR DESCRIPTION
Version 2.14.1 Release 

## 2.14.1
* Fixed: Settings, Autocomplete, and Native Search admin notices no longer appear on unrelated wp-admin screens (e.g. WooCommerce Edit Order).